### PR TITLE
fix 21 by adding kafka to pom 

### DIFF
--- a/geomesa-nifi-processors/pom.xml
+++ b/geomesa-nifi-processors/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <exclusions>


### PR DESCRIPTION
so dependencies end up in the nar correctly

Marked as provided in the geomasa-kafka-datastore packages.