### PR TITLE
add custom sft and converter validators

### DIFF
--- a/geomesa-nifi-processors/pom.xml
+++ b/geomesa-nifi-processors/pom.xml
@@ -106,6 +106,12 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.8.47</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/AbstractGeoIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/AbstractGeoIngestProcessor.scala
@@ -9,7 +9,7 @@
 
 package org.geomesa.nifi.geo
 
-import java.io.InputStream
+import java.io.{IOException, InputStream}
 
 import org.apache.nifi.annotation.lifecycle.{OnRemoved, OnScheduled}
 import org.apache.nifi.components.PropertyDescriptor
@@ -19,6 +19,7 @@ import org.apache.nifi.processor.io.InputStreamCallback
 import org.apache.nifi.processor.util.StandardValidators
 import org.geomesa.nifi.geo.AbstractGeoIngestProcessor.Properties._
 import org.geomesa.nifi.geo.AbstractGeoIngestProcessor.Relationships._
+import org.geomesa.nifi.geo.validators.{ConverterValidator, SimpleFeatureTypeValidator}
 import org.geotools.data.{DataStore, DataUtilities, FeatureWriter, Transaction}
 import org.geotools.filter.identity.FeatureIdImpl
 import org.locationtech.geomesa.convert
@@ -243,19 +244,19 @@ object AbstractGeoIngestProcessor {
       .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
       .build
 
-    // TODO create a custom validator
     val SftSpec = new PropertyDescriptor.Builder()
       .name("SftSpec")
       .description("Manually define a SimpleFeatureType (SFT) config spec")
       .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+      .addValidator(SimpleFeatureTypeValidator())
       .required(false)
       .build
 
-    // TODO create a custom validator
     val ConverterSpec = new PropertyDescriptor.Builder()
       .name("ConverterSpec")
       .description("Manually define a converter using typesafe config")
       .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+      .addValidator(ConverterValidator())
       .required(false)
       .build
 

--- a/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/AbstractGeoIngestProcessor.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/AbstractGeoIngestProcessor.scala
@@ -248,7 +248,7 @@ object AbstractGeoIngestProcessor {
       .name("SftSpec")
       .description("Manually define a SimpleFeatureType (SFT) config spec")
       .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-      .addValidator(SimpleFeatureTypeValidator())
+      .addValidator(SimpleFeatureTypeValidator)
       .required(false)
       .build
 
@@ -256,7 +256,7 @@ object AbstractGeoIngestProcessor {
       .name("ConverterSpec")
       .description("Manually define a converter using typesafe config")
       .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-      .addValidator(ConverterValidator())
+      .addValidator(ConverterValidator)
       .required(false)
       .build
 

--- a/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/ConverterValidator.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/ConverterValidator.scala
@@ -6,16 +6,11 @@ import org.locationtech.geomesa.convert.{ConfArgs, ConverterConfigResolver}
 /**
   * Simple validator of a convert spec. Tries to parse it to make sure that it can.
   */
-class ConverterValidator extends Validator{
+object ConverterValidator extends Validator{
   override def validate(subject: String, input: String, context: ValidationContext): ValidationResult = {
     ConverterConfigResolver.getArg(ConfArgs(input)) match {
-      case Left(_) => new ValidationResult.Builder().subject(subject).explanation(String.format("'%s' is not a valid converter", subject)).input(input).build;
+      case Left(_) => new ValidationResult.Builder().subject(subject).explanation(s"'$subject' is not a valid converter").input(input).build;
       case Right(_) => new ValidationResult.Builder().subject(subject).input(input).valid(true).build;
     }
   }
 }
-
-object ConverterValidator {
-  def apply() : ConverterValidator = new ConverterValidator()
-}
-

--- a/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/ConverterValidator.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/ConverterValidator.scala
@@ -1,0 +1,21 @@
+package org.geomesa.nifi.geo.validators
+
+import org.apache.nifi.components.{ValidationContext, ValidationResult, Validator}
+import org.locationtech.geomesa.convert.{ConfArgs, ConverterConfigResolver}
+
+/**
+  * Simple validator of a convert spec. Tries to parse it to make sure that it can.
+  */
+class ConverterValidator extends Validator{
+  override def validate(subject: String, input: String, context: ValidationContext): ValidationResult = {
+    ConverterConfigResolver.getArg(ConfArgs(input)) match {
+      case Left(_) => new ValidationResult.Builder().subject(subject).explanation(String.format("'%s' is not a valid converter", subject)).input(input).build;
+      case Right(_) => new ValidationResult.Builder().subject(subject).input(input).valid(true).build;
+    }
+  }
+}
+
+object ConverterValidator {
+  def apply() : ConverterValidator = new ConverterValidator()
+}
+

--- a/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/SimpleFeatureTypeValidator.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/SimpleFeatureTypeValidator.scala
@@ -6,16 +6,11 @@ import org.locationtech.geomesa.utils.geotools.{SftArgResolver, SftArgs}
 /**
   * Simple validator that tries to parse a given simple feature type to check that it is valid.
   */
-class SimpleFeatureTypeValidator extends Validator {
+object SimpleFeatureTypeValidator extends Validator {
   override def validate(subject: String, input: String, validationContext: ValidationContext): ValidationResult = {
     SftArgResolver.getArg(SftArgs(input, null)) match {
-      case Left(_) => new ValidationResult.Builder().subject(subject).explanation(String.format("'%s' is not a valid simple feature type", subject)).input(input).build;
+      case Left(_) => new ValidationResult.Builder().subject(subject).explanation(s"'$subject' is not a valid simple feature type").input(input).build;
       case Right(_) => new ValidationResult.Builder().subject(subject).input(input).valid(true).build;
     }
   }
-}
-
-
-object SimpleFeatureTypeValidator {
-  def apply() : SimpleFeatureTypeValidator = new SimpleFeatureTypeValidator()
 }

--- a/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/SimpleFeatureTypeValidator.scala
+++ b/geomesa-nifi-processors/src/main/scala/org/geomesa/nifi/geo/validators/SimpleFeatureTypeValidator.scala
@@ -1,0 +1,21 @@
+package org.geomesa.nifi.geo.validators
+
+import org.apache.nifi.components.{ValidationContext, ValidationResult, Validator}
+import org.locationtech.geomesa.utils.geotools.{SftArgResolver, SftArgs}
+
+/**
+  * Simple validator that tries to parse a given simple feature type to check that it is valid.
+  */
+class SimpleFeatureTypeValidator extends Validator {
+  override def validate(subject: String, input: String, validationContext: ValidationContext): ValidationResult = {
+    SftArgResolver.getArg(SftArgs(input, null)) match {
+      case Left(_) => new ValidationResult.Builder().subject(subject).explanation(String.format("'%s' is not a valid simple feature type", subject)).input(input).build;
+      case Right(_) => new ValidationResult.Builder().subject(subject).input(input).valid(true).build;
+    }
+  }
+}
+
+
+object SimpleFeatureTypeValidator {
+  def apply() : SimpleFeatureTypeValidator = new SimpleFeatureTypeValidator()
+}

--- a/geomesa-nifi-processors/src/test/scala/org/geomesa/nifi/geo/validators/TestSimpleFeatureTypeValidator.scala
+++ b/geomesa-nifi-processors/src/test/scala/org/geomesa/nifi/geo/validators/TestSimpleFeatureTypeValidator.scala
@@ -21,22 +21,20 @@ class TestSimpleFeatureTypeValidator {
 
   @Test
   def validTests() : Unit = {
-    val v = SimpleFeatureTypeValidator()
     val c = mock(classOf[ValidationContext])
 
     validInputs.foreach{ s =>
-      val result = v.validate("testThing", s, c)
+      val result = SimpleFeatureTypeValidator.validate("testThing", s, c)
       assertTrue("\"" + s + "\" should have been valid" , result.isValid)
     }
   }
 
   @Test
   def invalidTests() : Unit = {
-    val v = SimpleFeatureTypeValidator()
     val c = mock(classOf[ValidationContext])
 
     invalidInputs.foreach{ s =>
-      val result = v.validate("testThing", s, c)
+      val result = SimpleFeatureTypeValidator.validate("testThing", s, c)
       assertFalse("\"" + s + "\" should have been invalid" , result.isValid)
     }
   }

--- a/geomesa-nifi-processors/src/test/scala/org/geomesa/nifi/geo/validators/TestSimpleFeatureTypeValidator.scala
+++ b/geomesa-nifi-processors/src/test/scala/org/geomesa/nifi/geo/validators/TestSimpleFeatureTypeValidator.scala
@@ -1,0 +1,44 @@
+package org.geomesa.nifi.geo.validators
+
+import org.apache.nifi.components.ValidationContext
+import org.junit.Assert._
+import org.junit.Test
+import org.mockito.Mockito._
+
+class TestSimpleFeatureTypeValidator {
+
+  private val validInputs = List(
+    "geomesa {sfts {twitter = {fields = [{name = text, type = String}{name = username, type = String}{name = geom, type = Point, srid = 4326}]}}}",
+    "geomesa { sfts { twitter = {fields = []}} }"
+  )
+
+  private val invalidInputs = List(
+    "",
+    "dsjhgjkdsfhgkjfdshgjisfkh",
+    "geomesa { sfts {} }",
+    "geomesa { sfts { twitter = {}} }"
+  )
+
+  @Test
+  def validTests() : Unit = {
+    val v = SimpleFeatureTypeValidator()
+    val c = mock(classOf[ValidationContext])
+
+    validInputs.foreach{ s =>
+      val result = v.validate("testThing", s, c)
+      assertTrue("\"" + s + "\" should have been valid" , result.isValid)
+    }
+  }
+
+  @Test
+  def invalidTests() : Unit = {
+    val v = SimpleFeatureTypeValidator()
+    val c = mock(classOf[ValidationContext])
+
+    invalidInputs.foreach{ s =>
+      val result = v.validate("testThing", s, c)
+      assertFalse("\"" + s + "\" should have been invalid" , result.isValid)
+    }
+  }
+
+}


### PR DESCRIPTION
Resolve the two todo comments by adding custom validators for Simple feature types and converters.

Had a lot of problems which boiled down to invalid SFTs so this seemed like the easiest way to fix them. The resulting exceptions are not exactly helpful some of the time when you get this wrong. (Array index out of bounds etc) 