### PR TITLE
GEOMESA-3031 Simplify ingest from Kafka to other backends

### DIFF
--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/AvroIngestProcessor.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/AvroIngestProcessor.scala
@@ -196,8 +196,8 @@ object AvroIngestProcessor {
           .name("Use provided feature ID")
           .description("Use the feature ID from the Avro record, or generate a new one")
           .required(false)
-          .defaultValue("false")
           .allowableValues("true", "false")
+          .defaultValue("true")
           .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
           .build()
 
@@ -210,7 +210,7 @@ object AvroIngestProcessor {
     val AvroMatchMode: PropertyDescriptor =
       new PropertyDescriptor.Builder()
           .name("Avro SFT match mode")
-          .description("Determines how Avro SFT mismatches are handled (deprecated - use Schema Compatibility)")
+          .description("(DEPRECATED - use Schema Compatibility) Determines how Avro SFT mismatches are handled")
           .required(false)
           .allowableValues(ExactMatch, LenientMatch)
           .build()
@@ -219,7 +219,7 @@ object AvroIngestProcessor {
     val AvroSftName: PropertyDescriptor =
       new PropertyDescriptor.Builder()
           .name("SftName")
-          .description("Feature type name (deprecated - use FeatureNameOverride)")
+          .description("(DEPRECATED - use FeatureNameOverride) Feature type name")
           .required(false)
           .build()
   }

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/records/GeoAvroRecordSetWriterFactory.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/records/GeoAvroRecordSetWriterFactory.scala
@@ -9,7 +9,6 @@
 package org.geomesa.nifi.datastore.processor.records
 
 import java.io.OutputStream
-import java.util
 
 import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
 import org.apache.nifi.annotation.lifecycle.OnEnabled
@@ -31,7 +30,7 @@ class GeoAvroRecordSetWriterFactory extends AbstractControllerService with Recor
   private var options: OptionExtractor = _
 
   // NB: This is the same as what the InheritSchemaFromRecord Strategy does
-  override def getSchema(map: util.Map[String, String], recordSchema: RecordSchema): RecordSchema = recordSchema
+  override def getSchema(map: java.util.Map[String, String], recordSchema: RecordSchema): RecordSchema = recordSchema
 
   override def createWriter(
       logger: ComponentLog,
@@ -42,7 +41,7 @@ class GeoAvroRecordSetWriterFactory extends AbstractControllerService with Recor
     new GeoAvroRecordSetWriter(recordSchema, opts, outputStream)
   }
 
-  override def getSupportedPropertyDescriptors: util.List[PropertyDescriptor] = Props
+  override def getSupportedPropertyDescriptors: java.util.List[PropertyDescriptor] = Props
 
   @OnEnabled
   def setContext(context: ConfigurationContext): Unit = {
@@ -73,7 +72,7 @@ object GeoAvroRecordSetWriterFactory {
     private val converter = SimpleFeatureRecordConverter(recordSchema, options)
     private val writer = new AvroDataFileWriter(outputStream, converter.sft)
 
-    override def writeRecord(record: Record): util.Map[String, String] = {
+    override def writeRecord(record: Record): java.util.Map[String, String] = {
       val sf = converter.convert(record)
       writer.append(sf)
 

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/records/SimpleFeatureRecordConverter.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/records/SimpleFeatureRecordConverter.scala
@@ -131,6 +131,8 @@ object SimpleFeatureRecordConverter extends LazyLogging {
 
   import scala.collection.JavaConverters._
 
+  val DefaultIdCol = "id"
+
   private val gson = new GsonBuilder().serializeNulls().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX").create()
 
   private val cache = Caffeine.newBuilder().build(

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/pom.xml
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/pom.xml
@@ -37,6 +37,12 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.13</version>
+        </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>org.specs2</groupId>


### PR DESCRIPTION
* Set default nifi expressions in GeoAvroRecordSetWriter
* GetKafkaRecordProcessor fills in default expressions to eliminate manual config
* AvroToPut* processors default to use provided FID true

Signed-off-by: Emilio Lahr-Vivaz <elahrvivaz@ccri.com>