### PR TITLE
GEOMESA-3092 Lambda data store processor

### DIFF
--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/pom.xml
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/pom.xml
@@ -15,22 +15,89 @@
     <description>GeoMesa Accumulo processors</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-datastore-processors</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-beanutils</groupId>
-                    <artifactId>commons-beanutils-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-arrow-gt_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-main</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-opengis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-cql</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-metadata</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-render</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.jts</groupId>
+                    <artifactId>jts-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
@@ -38,6 +105,60 @@
         <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-core</artifactId>
+            <exclusions>
+                <!-- exclude hadoop 3 jars since we are still using 2.8 -->
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- provided dependencies inherited from our parent nar -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-avro-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
         </dependency>
 
         <!-- test -->
@@ -99,6 +220,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,1 @@
+org.geomesa.nifi.processors.accumulo.AccumuloDataStoreService

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -2,3 +2,8 @@ org.geomesa.nifi.processors.accumulo.AvroToPutGeoMesaAccumulo
 org.geomesa.nifi.processors.accumulo.PutGeoMesaAccumulo
 org.geomesa.nifi.processors.accumulo.PutGeoMesaAccumuloRecord
 org.geomesa.nifi.processors.accumulo.UpdateGeoMesaAccumuloRecord
+org.geomesa.nifi.datastore.processor.ConvertToGeoAvro
+org.geomesa.nifi.datastore.processor.geotools.AvroToPutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoToolsRecord
+org.geomesa.nifi.datastore.processor.geotools.UpdateGeoToolsRecord

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/AccumuloDataStoreService.scala
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/AccumuloDataStoreService.scala
@@ -1,0 +1,24 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.processors.accumulo
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+import org.apache.nifi.components.PropertyDescriptor
+import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
+import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
+import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreFactory
+
+@Tags(Array("geomesa", "geotools", "geo", "accumulo"))
+@CapabilityDescription("Service for connecting to GeoMesa Accumulo stores")
+class AccumuloDataStoreService
+    extends GeoMesaDataStoreService[AccumuloDataStoreFactory](AccumuloDataStoreService.Properties)
+
+object AccumuloDataStoreService extends PropertyDescriptorUtils {
+  val Properties: Seq[PropertyDescriptor] = createPropertyDescriptors(AccumuloDataStoreFactory)
+}

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/AccumuloProcessor.scala
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/AccumuloProcessor.scala
@@ -10,12 +10,12 @@ package org.geomesa.nifi.processors.accumulo
 
 import org.apache.nifi.components.{PropertyDescriptor, ValidationContext, ValidationResult}
 import org.apache.nifi.processor.ProcessContext
-import org.geomesa.nifi.datastore.processor.mixins.DataStoreProcessor
+import org.geomesa.nifi.datastore.processor.mixins.AbstractDataStoreProcessor
 import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
 import org.geomesa.nifi.datastore.services.DataStoreConfigService
-import org.locationtech.geomesa.accumulo.data.{AccumuloDataStoreFactory, AccumuloDataStoreParams}
+import org.locationtech.geomesa.accumulo.data.AccumuloDataStoreParams
 
-abstract class AccumuloProcessor extends DataStoreProcessor(AccumuloProcessor.AccumuloProperties) {
+abstract class AccumuloProcessor extends AbstractDataStoreProcessor(AccumuloProcessor.AccumuloProperties) {
 
   import AccumuloDataStoreParams._
   import AccumuloProcessor._
@@ -82,5 +82,5 @@ object AccumuloProcessor extends PropertyDescriptorUtils {
 
   private val AccumuloProperties =
     // don't require any properties because we are using the controller service
-    createPropertyDescriptors(AccumuloDataStoreFactory).map(unrequired) :+ GeoMesaConfigController
+    AccumuloDataStoreService.Properties.map(unrequired) :+ GeoMesaConfigController
 }

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/AvroToPutGeoMesaAccumulo.scala
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/AvroToPutGeoMesaAccumulo.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.accumulo
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.AvroIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{AvroIngestProcessor, AvroToPutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "avro", "accumulo", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[AccumuloDataStoreService], classOf[AvroToPutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class AvroToPutGeoMesaAccumulo extends AccumuloProcessor with AvroIngestProcessor

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/PutGeoMesaAccumulo.scala
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/PutGeoMesaAccumulo.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.accumulo
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.ConverterIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{ConverterIngestProcessor, PutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "convert", "accumulo", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[AccumuloDataStoreService], classOf[PutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaAccumulo extends AccumuloProcessor with ConverterIngestProcessor

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/PutGeoMesaAccumuloRecord.scala
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/PutGeoMesaAccumuloRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.accumulo
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{PutGeoMesa, PutGeoMesaRecord, RecordIngestProcessor}
 
 @Tags(Array("geomesa", "geo", "ingest", "records", "accumulo", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[AccumuloDataStoreService], classOf[PutGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaAccumuloRecord extends AccumuloProcessor with RecordIngestProcessor

--- a/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/UpdateGeoMesaAccumuloRecord.scala
+++ b/geomesa-accumulo-bundle/geomesa-accumulo-processors/src/main/scala/org/geomesa/nifi/processors/accumulo/UpdateGeoMesaAccumuloRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.accumulo
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordUpdateProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{RecordUpdateProcessor, UpdateGeoMesaRecord}
 
 @Tags(Array("geomesa", "geo", "update", "records", "accumulo", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[AccumuloDataStoreService], classOf[UpdateGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class UpdateGeoMesaAccumuloRecord extends AccumuloProcessor with RecordUpdateProcessor

--- a/geomesa-accumulo-bundle/geomesa-accumulo1-nar/pom.xml
+++ b/geomesa-accumulo-bundle/geomesa-accumulo1-nar/pom.xml
@@ -27,16 +27,15 @@
             <artifactId>geomesa-accumulo-processors</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-            <classifier>data</classifier>
-            <version>${geomesa.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-core</artifactId>
             <version>${accumulo-1.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/geomesa-accumulo-bundle/geomesa-accumulo2-nar/pom.xml
+++ b/geomesa-accumulo-bundle/geomesa-accumulo2-nar/pom.xml
@@ -27,10 +27,9 @@
             <artifactId>geomesa-accumulo-processors</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-            <classifier>data</classifier>
-            <version>${geomesa.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/pom.xml
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/pom.xml
@@ -15,6 +15,13 @@
     <description>Core datastore processors</description>
 
     <dependencies>
+
+        <!-- provided dependencies inherited from the geomesa-datastore-services-api-nar -->
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-api</artifactId>
@@ -48,84 +55,21 @@
             <artifactId>nifi-schema-registry-service-api</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.geomesa.nifi</groupId>
-            <artifactId>geomesa-datastore-services-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
-        </dependency>
         <!-- bring in postgis to make the PutGeoTools processor work with it out of the box -->
         <dependency>
             <groupId>org.geotools.jdbc</groupId>
             <artifactId>gt-jdbc-postgis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.media</groupId>
-            <artifactId>jai_core</artifactId>
-            <version>1.1.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
+            <!-- exclude dependencies provided by datastore-services-api-nar -->
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.curator</groupId>
-                    <artifactId>*</artifactId>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-main</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-compiler</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-reflect</artifactId>
         </dependency>
 
         <!-- test -->

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,2 +1,0 @@
-org.geomesa.nifi.datastore.processor.records.GeoAvroRecordSetWriterFactory
-

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,6 +1,0 @@
-org.geomesa.nifi.datastore.processor.ConvertToGeoAvro
-org.geomesa.nifi.datastore.processor.ConvertToGeoFile
-org.geomesa.nifi.datastore.processor.geotools.AvroToPutGeoTools
-org.geomesa.nifi.datastore.processor.geotools.PutGeoTools
-org.geomesa.nifi.datastore.processor.geotools.PutGeoToolsRecord
-org.geomesa.nifi.datastore.processor.geotools.UpdateGeoToolsRecord

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/AvroToPutGeoMesa.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/AvroToPutGeoMesa.scala
@@ -1,0 +1,15 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+
+@Tags(Array("geomesa", "geo", "ingest", "avro", "geotools"))
+@CapabilityDescription("Ingest GeoAvro files into GeoMesa")
+class AvroToPutGeoMesa extends AvroIngestProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesa.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesa.scala
@@ -1,0 +1,15 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+
+@Tags(Array("geomesa", "geo", "ingest", "convert", "geotools"))
+@CapabilityDescription("Convert and ingest data files into GeoMesa")
+class PutGeoMesa extends ConverterIngestProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesaRecord.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesaRecord.scala
@@ -1,0 +1,15 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+
+@Tags(Array("geomesa", "geo", "ingest", "records", "accumulo", "geotools"))
+@CapabilityDescription("Ingest records into GeoMesa")
+class PutGeoMesaRecord extends RecordIngestProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/UpdateGeoMesaRecord.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/UpdateGeoMesaRecord.scala
@@ -1,0 +1,15 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+
+@Tags(Array("geomesa", "geo", "update", "records", "geotools"))
+@CapabilityDescription("Update existing features in GeoMesa")
+class UpdateGeoMesaRecord extends RecordUpdateProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/AvroToPutGeoTools.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/AvroToPutGeoTools.scala
@@ -8,9 +8,12 @@
 
 package org.geomesa.nifi.datastore.processor.geotools
 
-import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
-import org.geomesa.nifi.datastore.processor.AvroIngestProcessor
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{AvroIngestProcessor, AvroToPutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "avro", "geotools"))
 @CapabilityDescription("Ingest GeoAvro files into a GeoTools data store")
+@DeprecationNotice(
+  alternatives = Array(classOf[PostgisDataStoreService], classOf[AvroToPutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class AvroToPutGeoTools extends GeoToolsProcessor with AvroIngestProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/GeoToolsProcessor.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/GeoToolsProcessor.scala
@@ -12,10 +12,10 @@ import org.apache.nifi.components.{PropertyDescriptor, ValidationContext, Valida
 import org.apache.nifi.expression.ExpressionLanguageScope
 import org.apache.nifi.processor._
 import org.apache.nifi.processor.util.StandardValidators
-import org.geomesa.nifi.datastore.processor.mixins.DataStoreProcessor
+import org.geomesa.nifi.datastore.processor.mixins.AbstractDataStoreProcessor
 import org.geotools.data.{DataStoreFactorySpi, DataStoreFinder}
 
-abstract class GeoToolsProcessor extends DataStoreProcessor(Seq.empty) {
+abstract class GeoToolsProcessor extends AbstractDataStoreProcessor(Seq.empty) {
 
   import scala.collection.JavaConverters._
 

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/PostgisDataStoreService.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/PostgisDataStoreService.scala
@@ -1,0 +1,20 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor.geotools
+
+import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
+import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
+import org.geotools.data.postgis.PostgisNGDataStoreFactory
+
+class PostgisDataStoreService
+    extends GeoMesaDataStoreService[PostgisNGDataStoreFactory](PostgisDataStoreService.Parameters)
+
+object PostgisDataStoreService extends PropertyDescriptorUtils {
+  private val Parameters = new PostgisNGDataStoreFactory().getParametersInfo.toSeq.map(createPropertyDescriptor)
+}

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/PutGeoTools.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/PutGeoTools.scala
@@ -8,9 +8,12 @@
 
 package org.geomesa.nifi.datastore.processor.geotools
 
-import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
-import org.geomesa.nifi.datastore.processor.ConverterIngestProcessor
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{ConverterIngestProcessor, PutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "convert", "geotools"))
 @CapabilityDescription("Convert and ingest data files into a GeoTools data store")
+@DeprecationNotice(
+  alternatives = Array(classOf[PostgisDataStoreService], classOf[PutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoTools extends GeoToolsProcessor with ConverterIngestProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/PutGeoToolsRecord.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/PutGeoToolsRecord.scala
@@ -8,9 +8,12 @@
 
 package org.geomesa.nifi.datastore.processor.geotools
 
-import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
-import org.geomesa.nifi.datastore.processor.RecordIngestProcessor
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{PutGeoMesaRecord, RecordIngestProcessor}
 
 @Tags(Array("geomesa", "geo", "ingest", "records", "geotools"))
 @CapabilityDescription("Ingest records into a GeoTools data store")
+@DeprecationNotice(
+  alternatives = Array(classOf[PostgisDataStoreService], classOf[PutGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoToolsRecord extends GeoToolsProcessor with RecordIngestProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/UpdateGeoToolsRecord.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/geotools/UpdateGeoToolsRecord.scala
@@ -8,9 +8,12 @@
 
 package org.geomesa.nifi.datastore.processor.geotools
 
-import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
-import org.geomesa.nifi.datastore.processor.RecordUpdateProcessor
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{RecordUpdateProcessor, UpdateGeoMesaRecord}
 
 @Tags(Array("geomesa", "geo", "update", "records", "geotools"))
 @CapabilityDescription("Update existing features in a GeoTools data store")
+@DeprecationNotice(
+  alternatives = Array(classOf[PostgisDataStoreService], classOf[UpdateGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class UpdateGeoToolsRecord extends GeoToolsProcessor with RecordUpdateProcessor

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/AbstractDataStoreProcessor.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/AbstractDataStoreProcessor.scala
@@ -1,0 +1,49 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor.mixins
+
+import org.apache.nifi.components.PropertyDescriptor
+import org.apache.nifi.context.PropertyContext
+import org.apache.nifi.processor.ProcessContext
+import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
+import org.geotools.data.{DataStore, DataStoreFinder}
+
+/**
+ * Abstract processor that uses a data store
+ *
+ * @param dataStoreProperties properties exposed through NiFi used to load the data store
+ */
+abstract class AbstractDataStoreProcessor(dataStoreProperties: Seq[PropertyDescriptor]) extends DataStoreProcessor {
+
+  import scala.collection.JavaConverters._
+
+  override protected def loadDataStore(context: ProcessContext): DataStore = {
+    val props = getDataStoreParams(context)
+    lazy val safeToLog = {
+      val sensitive = context.getProperties.keySet().asScala.collect { case p if p.isSensitive => p.getName }
+      props.map { case (k, v) => s"$k -> ${if (sensitive.contains(k)) { "***" } else { v }}" }
+    }
+    logger.trace(s"DataStore properties: ${safeToLog.mkString(", ")}")
+    val ds = DataStoreFinder.getDataStore(props.asJava)
+    require(ds != null, "Could not load datastore using provided parameters")
+    ds
+  }
+
+  /**
+   * Get params for looking up the data store, based on the current processor configuration
+   *
+   * @param context context
+   * @return
+   */
+  protected def getDataStoreParams(context: ProcessContext): Map[String, _] =
+    GeoMesaDataStoreService.getDataStoreParams(context, dataStoreProperties)
+
+  override protected def getTertiaryProperties: Seq[PropertyDescriptor] =
+    (super.getTertiaryProperties ++ dataStoreProperties).filterNot(_ == DataStoreProcessor.Properties.DataStoreService)
+}

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/AwsDataStoreProcessor.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/AwsDataStoreProcessor.scala
@@ -16,12 +16,13 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.nifi.components.PropertyDescriptor
 import org.apache.nifi.processor.ProcessContext
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderService
+import org.geomesa.nifi.datastore.processor.service.AwsDataStoreService
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
 
 /**
   * Trait with support for an AWSCredentialsProviderService
   */
-trait AwsDataStoreProcessor extends DataStoreProcessor {
+trait AwsDataStoreProcessor extends AbstractDataStoreProcessor {
 
   import scala.collection.JavaConverters._
 
@@ -33,11 +34,11 @@ trait AwsDataStoreProcessor extends DataStoreProcessor {
   protected def configParam: GeoMesaParam[String]
 
   override protected def getServiceProperties: Seq[PropertyDescriptor] =
-    super.getServiceProperties ++ Seq(AwsDataStoreProcessor.CredentialsServiceProperty)
+    super.getServiceProperties ++ Seq(AwsDataStoreService.Properties.CredentialsServiceProperty)
 
   override protected def getDataStoreParams(context: ProcessContext): Map[String, _] = {
     val base = super.getDataStoreParams(context)
-    val prop = context.getProperty(AwsDataStoreProcessor.CredentialsServiceProperty)
+    val prop = context.getProperty(AwsDataStoreService.Properties.CredentialsServiceProperty)
     val credentials = for {
       service  <- Option(prop.asControllerService(classOf[AWSCredentialsProviderService]))
       provider <- Option(service.getCredentialsProvider)
@@ -66,14 +67,4 @@ trait AwsDataStoreProcessor extends DataStoreProcessor {
         base ++ Map(configParam.key -> out.toString)
     }
   }
-}
-
-object AwsDataStoreProcessor {
-  private val CredentialsServiceProperty =
-    new PropertyDescriptor.Builder()
-        .name("AWS Credentials Provider service")
-        .description("The Controller Service that is used to obtain an AWS credentials provider")
-        .required(false)
-        .identifiesControllerService(classOf[AWSCredentialsProviderService])
-        .build()
 }

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/DataStoreIngestProcessor.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/DataStoreIngestProcessor.scala
@@ -144,8 +144,8 @@ trait DataStoreIngestProcessor extends DataStoreProcessor {
     logger.info(s"Shut down in ${System.currentTimeMillis() - start}ms")
   }
 
-  override protected def getSecondaryProperties: Seq[PropertyDescriptor] =
-    super.getSecondaryProperties ++ Seq(SchemaCompatibilityMode, WriteMode, ModifyAttribute)
+  override protected def getTertiaryProperties: Seq[PropertyDescriptor] =
+    super.getTertiaryProperties ++ Seq(SchemaCompatibilityMode, WriteMode, ModifyAttribute)
 
   override protected def getConfigProperties: Seq[PropertyDescriptor] =
     super.getConfigProperties ++ Seq(FeatureWriterCaching, FeatureWriterCacheTimeout, NifiBatchSize)

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/DataStoreProcessor.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/DataStoreProcessor.scala
@@ -9,65 +9,34 @@
 package org.geomesa.nifi.datastore.processor.mixins
 
 import org.apache.nifi.components.PropertyDescriptor
-import org.apache.nifi.context.PropertyContext
 import org.apache.nifi.processor.ProcessContext
-import org.geotools.data.{DataStore, DataStoreFinder}
+import org.geomesa.nifi.datastore.services.DataStoreService
+import org.geotools.data.DataStore
 
 /**
  * Abstract processor that uses a data store
- *
- * @param dataStoreProperties properties exposed through NiFi used to load the data store
  */
-abstract class DataStoreProcessor(dataStoreProperties: Seq[PropertyDescriptor]) extends BaseProcessor {
+trait DataStoreProcessor extends BaseProcessor {
 
-  import scala.collection.JavaConverters._
+  import DataStoreProcessor.Properties.DataStoreService
 
-  protected def loadDataStore(context: ProcessContext): DataStore = {
-    val props = getDataStoreParams(context)
-    lazy val safeToLog = {
-      val sensitive = context.getProperties.keySet().asScala.collect { case p if p.isSensitive => p.getName }
-      props.map { case (k, v) => s"$k -> ${if (sensitive.contains(k)) { "***" } else { v }}" }
-    }
-    logger.trace(s"DataStore properties: ${safeToLog.mkString(", ")}")
-    val ds = DataStoreFinder.getDataStore(props.asJava)
-    require(ds != null, "Could not load datastore using provided parameters")
-    ds
-  }
-
-  /**
-   * Get params for looking up the data store, based on the current processor configuration
-   *
-   * @param context context
-   * @return
-   */
-  protected def getDataStoreParams(context: ProcessContext): Map[String, _] =
-    DataStoreProcessor.getDataStoreParams(context, dataStoreProperties)
+  protected def loadDataStore(context: ProcessContext): DataStore =
+    context.getProperty(DataStoreService).asControllerService(classOf[DataStoreService]).loadDataStore()
 
   override protected def getTertiaryProperties: Seq[PropertyDescriptor] =
-    super.getTertiaryProperties ++ dataStoreProperties
+    Seq(DataStoreService) ++ super.getTertiaryProperties
 }
 
 object DataStoreProcessor {
-
-  /**
-   * Get data store parameter map based on a nifi context
-   *
-   * @param context context
-   * @param props property descriptors corresponding to the data store factory params
-   * @return
-   */
-  def getDataStoreParams(context: PropertyContext, props: Seq[PropertyDescriptor]): Map[String, _] = {
-    val builder = Map.newBuilder[String, AnyRef]
-    props.foreach { p =>
-      val property = {
-        val prop = context.getProperty(p)
-        if (p.isExpressionLanguageSupported) { prop.evaluateAttributeExpressions() }  else { prop }
-      }
-      val value = property.getValue
-      if (value != null) {
-        builder += p.getName -> value
-      }
-    }
-    builder.result
+  object Properties {
+    val DataStoreService: PropertyDescriptor =
+      new PropertyDescriptor.Builder()
+          .name("DataStoreService")
+          .displayName("DataStore Service")
+          .required(true)
+          .description("The DataStore to use")
+          .identifiesControllerService(classOf[DataStoreService])
+          .build()
   }
 }
+

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/package.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/package.scala
@@ -30,6 +30,21 @@ package object processor {
    */
   def invalid(message: String): ValidationResult = new ValidationResult.Builder().input(message).build()
 
+  def invalid(subject: String, error: Throwable, input: Option[String] = None): ValidationResult = {
+    val builder = new ValidationResult.Builder().subject(subject)
+    input.foreach(builder.input)
+    val explanation = new StringBuilder
+    var e = error
+    while (e != null) {
+      if (explanation.nonEmpty) {
+        explanation.append("\n  Caused by: ")
+      }
+      explanation.append(e.toString)
+      e = e.getCause
+    }
+    builder.explanation(explanation.toString).build()
+  }
+
   object Relationships {
     val SuccessRelationship: Relationship = new Relationship.Builder().name("success").description("Success").build()
     val FailureRelationship: Relationship = new Relationship.Builder().name("failure").description("Failure").build()

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/service/AwsDataStoreService.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/service/AwsDataStoreService.scala
@@ -1,0 +1,81 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor.service
+
+import java.io.{ByteArrayInputStream, StringWriter}
+import java.nio.charset.StandardCharsets
+
+import com.amazonaws.auth.AWSSessionCredentials
+import org.apache.hadoop.conf.Configuration
+import org.apache.nifi.components.PropertyDescriptor
+import org.apache.nifi.context.PropertyContext
+import org.apache.nifi.controller.ConfigurationContext
+import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderService
+import org.geotools.data.DataStoreFactorySpi
+import org.locationtech.geomesa.utils.geotools.GeoMesaParam
+
+import scala.reflect.ClassTag
+
+/**
+ * Aws data store integration
+ *
+ * @param descriptors data store descriptors
+ * @param configParam parameter for embedding hadoop &lt;configuration&gt; xml, used to pass the AWS credentials
+ */
+class AwsDataStoreService[T <: DataStoreFactorySpi: ClassTag](
+    descriptors: Seq[PropertyDescriptor],
+    configParam: GeoMesaParam[String]
+  ) extends GeoMesaDataStoreService(descriptors ++ Seq(AwsDataStoreService.Properties.CredentialsServiceProperty)) {
+
+  import scala.collection.JavaConverters._
+
+  override protected def getDataStoreParams(context: PropertyContext): Map[String, _ <: AnyRef] = {
+    val base = super.getDataStoreParams(context)
+    val prop = context.getProperty(AwsDataStoreService.Properties.CredentialsServiceProperty)
+    val credentials = for {
+      service  <- Option(prop.asControllerService(classOf[AWSCredentialsProviderService]))
+      provider <- Option(service.getCredentialsProvider)
+    } yield {
+      provider.getCredentials
+    }
+    credentials match {
+      case None => base
+      case Some(c) =>
+        val config = new Configuration(false)
+        config.set("fs.s3a.access.key", c.getAWSAccessKeyId)
+        config.set("fs.s3a.secret.key", c.getAWSSecretKey)
+        c match {
+          case s: AWSSessionCredentials =>
+            config.set("fs.s3a.session.token", s.getSessionToken)
+            // TODO handle session renewal?
+            config.set("fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider")
+          case _ => // no-op
+        }
+        // add any config that was populated by the user so it's not lost
+        configParam.lookupOpt(base.asJava).foreach { c =>
+          config.addResource(new ByteArrayInputStream(c.getBytes(StandardCharsets.UTF_8)))
+        }
+        val out = new StringWriter()
+        config.writeXml(out)
+        base ++ Map(configParam.key -> out.toString)
+    }
+  }
+}
+
+object AwsDataStoreService {
+  object Properties {
+    val CredentialsServiceProperty: PropertyDescriptor =
+      new PropertyDescriptor.Builder()
+          .name("AWS Credentials Provider service")
+          .description("The Controller Service that is used to obtain an AWS credentials provider")
+          .required(false)
+          .identifiesControllerService(classOf[AWSCredentialsProviderService])
+          .build()
+  }
+}

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/service/GeoMesaDataStoreService.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/service/GeoMesaDataStoreService.scala
@@ -1,0 +1,134 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.processor
+package service
+
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+import org.apache.nifi.annotation.lifecycle.{OnDisabled, OnEnabled}
+import org.apache.nifi.components.{PropertyDescriptor, ValidationContext, ValidationResult}
+import org.apache.nifi.context.PropertyContext
+import org.apache.nifi.controller.{AbstractControllerService, ConfigurationContext}
+import org.geomesa.nifi.datastore.services.DataStoreService
+import org.geotools.data.{DataStore, DataStoreFactorySpi}
+
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
+
+/**
+ * Data store controller service
+ *
+ * @param descriptors data store descriptors
+ */
+class GeoMesaDataStoreService[T <: DataStoreFactorySpi: ClassTag](descriptors: Seq[PropertyDescriptor])
+    extends AbstractControllerService with DataStoreService {
+
+  import scala.collection.JavaConverters._
+
+  private val params = new java.util.HashMap[String, AnyRef]()
+  private val sensitive = descriptors.collect { case d if d.isSensitive => d.getName }.toSet
+  private val stores = Collections.newSetFromMap(new ConcurrentHashMap[DataStore, java.lang.Boolean]())
+  private val valid = new AtomicReference[java.util.Collection[ValidationResult]](null)
+
+  override final def getDataStoreParams: java.util.Map[String, _] =
+    Collections.unmodifiableMap[String, AnyRef](params)
+
+  override final def loadDataStore: DataStore = {
+    val store = tryGetDataStore(params).get
+    stores.add(store)
+    store
+  }
+
+  @OnEnabled
+  final def onEnabled(context: ConfigurationContext): Unit = {
+    params.clear()
+    getDataStoreParams(context).foreach { case (k, v) => params.put(k, v) }
+    logParams("Enabled", params.asScala)
+  }
+
+  @OnDisabled
+  final def onDisabled(): Unit = {
+    stores.asScala.foreach { ds =>
+      try { ds.dispose() } catch {
+        case NonFatal(e) => getLogger.warn(s"Error disposing store $ds:", e)
+      }
+    }
+    stores.clear()
+  }
+
+  protected def getDataStoreParams(context: PropertyContext): Map[String, _ <: AnyRef] =
+    GeoMesaDataStoreService.getDataStoreParams(context, descriptors)
+
+  protected def tryGetDataStore(params: java.util.Map[String, AnyRef]): Try[DataStore] =
+    GeoMesaDataStoreService.tryGetDataStore[T](params)
+
+  override def onPropertyModified(descriptor: PropertyDescriptor, oldValue: String, newValue: String): Unit =
+    valid.set(null)
+
+  override protected def getSupportedPropertyDescriptors: java.util.List[PropertyDescriptor] = descriptors.asJava
+
+  override protected def customValidate(context: ValidationContext): java.util.Collection[ValidationResult] = {
+    Option(valid.get).getOrElse {
+      val params = getDataStoreParams(context)
+      logParams("Validation", params)
+      val result = tryGetDataStore(params.asJava) match {
+        case Success(ds) => ds.dispose(); Collections.emptySet[ValidationResult]()
+        case Failure(e)  => Collections.singleton(invalid(getClass.getSimpleName, e))
+      }
+      valid.set(result)
+      result
+    }
+  }
+
+  private def logParams(phase: String, params: scala.collection.Map[String, _]): Unit = {
+    lazy val safeToLog = params.map { case (k, v) => s"$k -> ${if (sensitive.contains(k)) { "***" } else { v }}" }
+    getLogger.trace(s"$phase: DataStore parameters: ${safeToLog.mkString(", ")}")
+  }
+
+  override def toString: String = s"${getClass.getSimpleName}[id=$getIdentifier]"
+}
+
+object GeoMesaDataStoreService {
+
+  /**
+   * Get data store parameter map based on a nifi context
+   *
+   * @param context context
+   * @param props property descriptors corresponding to the data store factory params
+   * @return
+   */
+  def getDataStoreParams(context: PropertyContext, props: Seq[PropertyDescriptor]): Map[String, AnyRef] = {
+    val builder = Map.newBuilder[String, AnyRef]
+    props.foreach { p =>
+      val property = {
+        val prop = context.getProperty(p)
+        if (p.isExpressionLanguageSupported) { prop.evaluateAttributeExpressions() }  else { prop }
+      }
+      val value = property.getValue
+      if (value != null) {
+        builder += p.getName -> value
+      }
+    }
+    builder.result
+  }
+
+  private def tryGetDataStore[T <: DataStoreFactorySpi: ClassTag](params: java.util.Map[String, _]): Try[DataStore] = {
+    Try {
+      val factory = implicitly[ClassTag[T]].runtimeClass.newInstance().asInstanceOf[T]
+      val store = factory.createDataStore(params.asInstanceOf[java.util.Map[String, java.io.Serializable]])
+      if (store == null) {
+        throw new IllegalArgumentException("Could not load datastore using provided parameters")
+      }
+      store
+    }
+  }
+}

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/utils/PropertyDescriptorUtils.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/utils/PropertyDescriptorUtils.scala
@@ -21,6 +21,8 @@ import scala.util.control.NonFatal
 
 trait PropertyDescriptorUtils extends LazyLogging {
 
+  import scala.collection.JavaConverters._
+
   /**
    * Create descriptors for a data store
    *
@@ -69,7 +71,13 @@ trait PropertyDescriptorUtils extends LazyLogging {
       builder.allowableValues("true", "false")
     } else {
       Option(param.metadata.get(Parameter.OPTIONS)).foreach { enum =>
-        try { builder.allowableValues(new java.util.HashSet(enum.asInstanceOf[java.util.List[String]])) } catch {
+        try {
+          val allowed = new java.util.HashSet[String]()
+          enum.asInstanceOf[java.util.List[_]].asScala.foreach(e => allowed.add(e.toString))
+          if (!allowed.isEmpty) {
+            builder.allowableValues(allowed)
+          }
+        } catch {
           case NonFatal(e) => logger.warn(s"Error trying to set allowable values for ${param.getName}: $enum", e)
         }
       }

--- a/geomesa-datastore-bundle/geomesa-datastore-services-api-nar/pom.xml
+++ b/geomesa-datastore-bundle/geomesa-datastore-services-api-nar/pom.xml
@@ -18,6 +18,7 @@
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>compile</scope>
         </dependency>
         <!-- nars are allowed to depend on at most 1 nar, which will act as a 'parent' and share its
              classpath at runtime. see https://nifi.apache.org/docs/nifi-docs/html/developer-guide.html#nars -->

--- a/geomesa-datastore-bundle/geomesa-datastore-services-api/pom.xml
+++ b/geomesa-datastore-bundle/geomesa-datastore-services-api/pom.xml
@@ -15,10 +15,101 @@
     <description>GeoMesa controller services API</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
+            <classifier>data</classifier>
+            <version>${geomesa.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-render</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.media</groupId>
+            <artifactId>jai_core</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-aws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+        </dependency>
+
+        <!-- provided dependencies -->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-api</artifactId>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/geomesa-datastore-bundle/geomesa-datastore-services-api/src/main/java/org/geomesa/nifi/datastore/services/DataStoreService.java
+++ b/geomesa-datastore-bundle/geomesa-datastore-services-api/src/main/java/org/geomesa/nifi/datastore/services/DataStoreService.java
@@ -1,0 +1,17 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.datastore.services;
+
+import org.apache.nifi.controller.ControllerService;
+import org.geotools.data.DataStore;
+
+public interface DataStoreService extends ControllerService {
+    java.util.Map<String, ?> getDataStoreParams();
+    DataStore loadDataStore();
+}

--- a/geomesa-datastore-bundle/geomesa-datastore-services/pom.xml
+++ b/geomesa-datastore-bundle/geomesa-datastore-services/pom.xml
@@ -15,9 +15,17 @@
     <description>GeoMesa controller service implementations</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-processors</artifactId>
+        </dependency>
+
+        <!-- provided dependencies inherited from the geomesa-datastore-services-api-nar -->
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -27,6 +35,7 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-processor-utils</artifactId>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/geomesa-datastore-bundle/geomesa-datastore-services/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-datastore-bundle/geomesa-datastore-services/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,1 +1,3 @@
 org.geomesa.nifi.datastore.impl.AccumuloDataStoreConfigControllerService
+org.geomesa.nifi.datastore.processor.records.GeoAvroRecordSetWriterFactory
+org.geomesa.nifi.datastore.processor.geotools.PostgisDataStoreService

--- a/geomesa-datastore-bundle/geomesa-datastore-services/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/geomesa-datastore-bundle/geomesa-datastore-services/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,5 @@
+org.geomesa.nifi.datastore.processor.AvroToPutGeoMesa
+org.geomesa.nifi.datastore.processor.PutGeoMesa
+org.geomesa.nifi.datastore.processor.PutGeoMesaRecord
+org.geomesa.nifi.datastore.processor.UpdateGeoMesaRecord
+org.geomesa.nifi.datastore.processor.ConvertToGeoFile

--- a/geomesa-fs-bundle/geomesa-fs-nar/pom.xml
+++ b/geomesa-fs-bundle/geomesa-fs-nar/pom.xml
@@ -26,12 +26,6 @@
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-fs-processors</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-            <classifier>data</classifier>
-            <version>${geomesa.version}</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/geomesa-fs-bundle/geomesa-fs-processors/pom.xml
+++ b/geomesa-fs-bundle/geomesa-fs-processors/pom.xml
@@ -15,17 +15,154 @@
     <description>GeoMesa File System processor implementation</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-datastore-processors</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-fs-datastore_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-common_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-fs-storage-api_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-fs-storage-common_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-arrow-gt_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-main</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-opengis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-cql</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-metadata</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-render</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-coverage</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.jts</groupId>
+                    <artifactId>jts-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.pureconfig</groupId>
+                    <artifactId>pureconfig_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- provided dependencies inherited from our parent nar -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-fs-tools_${scala.binary.version}</artifactId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-avro-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
         </dependency>
 
         <!-- test -->

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,1 @@
+org.geomesa.nifi.processors.fs.FileSystemDataStoreService

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -2,3 +2,8 @@ org.geomesa.nifi.processors.fs.AvroToPutGeoMesaFileSystem
 org.geomesa.nifi.processors.fs.PutGeoMesaFileSystem
 org.geomesa.nifi.processors.fs.PutGeoMesaFileSystemRecord
 org.geomesa.nifi.processors.fs.UpdateGeoMesaFileSystemRecord
+org.geomesa.nifi.datastore.processor.ConvertToGeoAvro
+org.geomesa.nifi.datastore.processor.geotools.AvroToPutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoToolsRecord
+org.geomesa.nifi.datastore.processor.geotools.UpdateGeoToolsRecord

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/AvroToPutGeoMesaFileSystem.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/AvroToPutGeoMesaFileSystem.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.fs
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.AvroIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{AvroIngestProcessor, AvroToPutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "avro", "hdfs", "s3", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[FileSystemDataStoreService], classOf[AvroToPutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class AvroToPutGeoMesaFileSystem extends FileSystemIngestProcessor with AvroIngestProcessor

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemDataStoreService.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemDataStoreService.scala
@@ -19,7 +19,6 @@ import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory.FileSystemDat
 @CapabilityDescription("Service for connecting to GeoMesa FileSystem stores")
 class FileSystemDataStoreService
     extends AwsDataStoreService[FileSystemDataStoreFactory](FileSystemDataStoreService.Properties, FileSystemDataStoreParams.ConfigsParam)
-// TODO partition scheme...
 
 object FileSystemDataStoreService extends PropertyDescriptorUtils {
   val Properties: Seq[PropertyDescriptor] = createPropertyDescriptors(FileSystemDataStoreFactory)

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemDataStoreService.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemDataStoreService.scala
@@ -1,0 +1,26 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.processors.fs
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+import org.apache.nifi.components.PropertyDescriptor
+import org.geomesa.nifi.datastore.processor.service.AwsDataStoreService
+import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
+import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory
+import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory.FileSystemDataStoreParams
+
+@Tags(Array("geomesa", "geotools", "geo", "hdfs", "s3"))
+@CapabilityDescription("Service for connecting to GeoMesa FileSystem stores")
+class FileSystemDataStoreService
+    extends AwsDataStoreService[FileSystemDataStoreFactory](FileSystemDataStoreService.Properties, FileSystemDataStoreParams.ConfigsParam)
+// TODO partition scheme...
+
+object FileSystemDataStoreService extends PropertyDescriptorUtils {
+  val Properties: Seq[PropertyDescriptor] = createPropertyDescriptors(FileSystemDataStoreFactory)
+}

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemIngestProcessor.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemIngestProcessor.scala
@@ -12,14 +12,14 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled
 import org.apache.nifi.components.PropertyDescriptor
 import org.apache.nifi.processor.ProcessContext
 import org.apache.nifi.processor.util.StandardValidators
-import org.geomesa.nifi.datastore.processor.mixins.{AwsDataStoreProcessor, DataStoreIngestProcessor, DataStoreProcessor}
+import org.geomesa.nifi.datastore.processor.mixins.{AbstractDataStoreProcessor, AwsDataStoreProcessor, DataStoreIngestProcessor}
 import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory.FileSystemDataStoreParams
-import org.locationtech.geomesa.fs.tools.utils.PartitionSchemeArgResolver
+import org.locationtech.geomesa.fs.storage.common.utils.PartitionSchemeArgResolver
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
 import org.opengis.feature.simple.SimpleFeatureType
 
 abstract class FileSystemIngestProcessor
-    extends DataStoreProcessor(FileSystemIngestProcessor.FileSystemProperties)
+    extends AbstractDataStoreProcessor(FileSystemIngestProcessor.FileSystemProperties)
         with DataStoreIngestProcessor
         with AwsDataStoreProcessor {
 
@@ -60,5 +60,5 @@ object FileSystemIngestProcessor {
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .build()
 
-  private val FileSystemProperties = FileSystemProcessor.FileSystemProperties :+ PartitionSchemeParam
+  private val FileSystemProperties = FileSystemDataStoreService.Properties :+ PartitionSchemeParam
 }

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemProcessor.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/FileSystemProcessor.scala
@@ -8,17 +8,11 @@
 
 package org.geomesa.nifi.processors.fs
 
-import org.geomesa.nifi.datastore.processor.mixins.{AwsDataStoreProcessor, DataStoreProcessor}
-import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
-import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory
+import org.geomesa.nifi.datastore.processor.mixins.{AbstractDataStoreProcessor, AwsDataStoreProcessor}
 import org.locationtech.geomesa.fs.data.FileSystemDataStoreFactory.FileSystemDataStoreParams
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
 
 abstract class FileSystemProcessor
-    extends DataStoreProcessor(FileSystemProcessor.FileSystemProperties) with AwsDataStoreProcessor {
+    extends AbstractDataStoreProcessor(FileSystemDataStoreService.Properties) with AwsDataStoreProcessor {
   override protected def configParam: GeoMesaParam[String] = FileSystemDataStoreParams.ConfigsParam
-}
-
-object FileSystemProcessor extends PropertyDescriptorUtils {
-  private [fs] val FileSystemProperties = createPropertyDescriptors(FileSystemDataStoreFactory)
 }

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/PutGeoMesaFileSystem.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/PutGeoMesaFileSystem.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.fs
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.ConverterIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{ConverterIngestProcessor, PutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "convert", "hdfs", "s3", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[FileSystemDataStoreService], classOf[PutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaFileSystem extends FileSystemIngestProcessor with ConverterIngestProcessor

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/PutGeoMesaFileSystemRecord.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/PutGeoMesaFileSystemRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.fs
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{PutGeoMesaRecord, RecordIngestProcessor}
 
 @Tags(Array("geomesa", "geo", "ingest", "records", "hdfs", "s3", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[FileSystemDataStoreService], classOf[PutGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaFileSystemRecord extends FileSystemIngestProcessor with RecordIngestProcessor

--- a/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/UpdateGeoMesaFileSystemRecord.scala
+++ b/geomesa-fs-bundle/geomesa-fs-processors/src/main/scala/org/geomesa/nifi/processors/fs/UpdateGeoMesaFileSystemRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.fs
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordUpdateProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{RecordUpdateProcessor, UpdateGeoMesaRecord}
 
 @Tags(Array("geomesa", "geo", "update", "records", "hdfs", "s3", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[FileSystemDataStoreService], classOf[UpdateGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class UpdateGeoMesaFileSystemRecord extends FileSystemProcessor with RecordUpdateProcessor

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/pom.xml
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/pom.xml
@@ -15,53 +15,160 @@
     <description>GeoMesa HBase processor implementations</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-datastore-processors</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-arrow-gt_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-main</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-opengis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-cql</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-metadata</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-render</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.jts</groupId>
+                    <artifactId>jts-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-protocol</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.curator</groupId>
+                    <groupId>org.apache.hadoop</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client</artifactId>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-protocol</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- provided dependencies inherited from our parent nar -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-avro-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
         </dependency>
 
         <!-- test -->

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,1 @@
+org.geomesa.nifi.processors.hbase.HBaseDataStoreService

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -2,3 +2,8 @@ org.geomesa.nifi.processors.hbase.AvroToPutGeoMesaHBase
 org.geomesa.nifi.processors.hbase.PutGeoMesaHBase
 org.geomesa.nifi.processors.hbase.PutGeoMesaHBaseRecord
 org.geomesa.nifi.processors.hbase.UpdateGeoMesaHBaseRecord
+org.geomesa.nifi.datastore.processor.ConvertToGeoAvro
+org.geomesa.nifi.datastore.processor.geotools.AvroToPutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoToolsRecord
+org.geomesa.nifi.datastore.processor.geotools.UpdateGeoToolsRecord

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/AvroToPutGeoMesaHBase.scala
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/AvroToPutGeoMesaHBase.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.hbase
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.AvroIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{AvroIngestProcessor, AvroToPutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "avro", "hbase", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[HBaseDataStoreService], classOf[AvroToPutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class AvroToPutGeoMesaHBase extends HBaseProcessor with AvroIngestProcessor

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/HBaseDataStoreService.scala
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/HBaseDataStoreService.scala
@@ -1,0 +1,24 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.processors.hbase
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+import org.apache.nifi.components.PropertyDescriptor
+import org.geomesa.nifi.datastore.processor.service.AwsDataStoreService
+import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
+import org.locationtech.geomesa.hbase.data.{HBaseDataStoreFactory, HBaseDataStoreParams}
+
+@Tags(Array("geomesa", "geotools", "geo", "hbase"))
+@CapabilityDescription("Service for connecting to GeoMesa HBase stores")
+class HBaseDataStoreService
+    extends AwsDataStoreService[HBaseDataStoreFactory](HBaseDataStoreService.Properties, HBaseDataStoreParams.ConfigsParam)
+
+object HBaseDataStoreService extends PropertyDescriptorUtils {
+  val Properties: Seq[PropertyDescriptor] = createPropertyDescriptors(HBaseDataStoreFactory)
+}

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/HBaseProcessor.scala
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/HBaseProcessor.scala
@@ -8,12 +8,13 @@
 
 package org.geomesa.nifi.processors.hbase
 
-import org.geomesa.nifi.datastore.processor.mixins.{AwsDataStoreProcessor, DataStoreProcessor}
+import org.geomesa.nifi.datastore.processor.mixins.{AbstractDataStoreProcessor, AwsDataStoreProcessor}
 import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
 import org.locationtech.geomesa.hbase.data.{HBaseDataStoreFactory, HBaseDataStoreParams}
 import org.locationtech.geomesa.utils.geotools.GeoMesaParam
 
-abstract class HBaseProcessor extends DataStoreProcessor(HBaseProcessor.HBaseProperties) with AwsDataStoreProcessor {
+abstract class HBaseProcessor
+    extends AbstractDataStoreProcessor(HBaseProcessor.HBaseProperties) with AwsDataStoreProcessor {
   override protected def configParam: GeoMesaParam[String] = HBaseDataStoreParams.ConfigsParam
 }
 

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/PutGeoMesaHBase.scala
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/PutGeoMesaHBase.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.hbase
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.ConverterIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{ConverterIngestProcessor, PutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "convert", "hbase", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[HBaseDataStoreService], classOf[PutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaHBase extends HBaseProcessor with ConverterIngestProcessor

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/PutGeoMesaHBaseRecord.scala
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/PutGeoMesaHBaseRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.hbase
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{PutGeoMesaRecord, RecordIngestProcessor}
 
 @Tags(Array("geomesa", "geo", "ingest", "records", "hbase", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[HBaseDataStoreService], classOf[PutGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaHBaseRecord extends HBaseProcessor with RecordIngestProcessor

--- a/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/UpdateGeoMesaHBaseRecord.scala
+++ b/geomesa-hbase-bundle/geomesa-hbase-processors/src/main/scala/org/geomesa/nifi/processors/hbase/UpdateGeoMesaHBaseRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.hbase
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordUpdateProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{RecordUpdateProcessor, UpdateGeoMesaRecord}
 
 @Tags(Array("geomesa", "geo", "update", "records", "hbase", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[HBaseDataStoreService], classOf[UpdateGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class UpdateGeoMesaHBaseRecord extends HBaseProcessor with RecordUpdateProcessor

--- a/geomesa-hbase-bundle/geomesa-hbase1-nar/pom.xml
+++ b/geomesa-hbase-bundle/geomesa-hbase1-nar/pom.xml
@@ -26,29 +26,46 @@
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-hbase-processors</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-            <classifier>data</classifier>
-            <version>${geomesa.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-common</artifactId>
             <version>${hbase-1.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
             <version>${hbase-1.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-protocol</artifactId>
             <version>${hbase-1.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/geomesa-hbase-bundle/geomesa-hbase2-nar/pom.xml
+++ b/geomesa-hbase-bundle/geomesa-hbase2-nar/pom.xml
@@ -26,11 +26,11 @@
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-hbase-processors</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-            <classifier>data</classifier>
-            <version>${geomesa.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/geomesa-kafka-bundle/geomesa-kafka-nar/pom.xml
+++ b/geomesa-kafka-bundle/geomesa-kafka-nar/pom.xml
@@ -25,12 +25,17 @@
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-kafka-processors</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.typesafe.scala-logging</groupId>
+                    <artifactId>scala-logging_${scala.binary.version}</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-            <classifier>data</classifier>
-            <version>${geomesa.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/pom.xml
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/pom.xml
@@ -15,13 +15,104 @@
     <description>GeoMesa Kafka processor implementations</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-datastore-processors</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-arrow-gt_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-metrics-core_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-main</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-opengis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-cql</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-metadata</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-render</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.jts</groupId>
+                    <artifactId>jts-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-reflect</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -31,6 +122,21 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.typesafe.scala-logging</groupId>
+                    <artifactId>scala-logging_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -43,7 +149,46 @@
             <version>1.13</version>
         </dependency>
 
+        <!-- provided dependencies inherited from our parent nar -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-avro-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
+        </dependency>
+
         <!-- test -->
+
         <dependency>
             <groupId>org.specs2</groupId>
             <artifactId>specs2-core_${scala.binary.version}</artifactId>

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,1 @@
+org.geomesa.nifi.processors.kafka.KafkaDataStoreService

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -2,3 +2,8 @@ org.geomesa.nifi.processors.kafka.PutGeoMesaKafka
 org.geomesa.nifi.processors.kafka.PutGeoMesaKafkaRecord
 org.geomesa.nifi.processors.kafka.AvroToPutGeoMesaKafka
 org.geomesa.nifi.processors.kafka.GetGeoMesaKafkaRecord
+org.geomesa.nifi.datastore.processor.ConvertToGeoAvro
+org.geomesa.nifi.datastore.processor.geotools.AvroToPutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoToolsRecord
+org.geomesa.nifi.datastore.processor.geotools.UpdateGeoToolsRecord

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/AvroToPutGeoMesaKafka.scala
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/AvroToPutGeoMesaKafka.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.kafka
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.AvroIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{AvroIngestProcessor, AvroToPutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "avro", "kafka", "stream", "streaming", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[KafkaDataStoreService], classOf[AvroToPutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class AvroToPutGeoMesaKafka extends KafkaProcessor with AvroIngestProcessor

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/GetGeoMesaKafkaRecord.scala
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/GetGeoMesaKafkaRecord.scala
@@ -27,9 +27,9 @@ import org.apache.nifi.processor._
 import org.apache.nifi.processor.util.StandardValidators
 import org.apache.nifi.serialization.RecordSetWriterFactory
 import org.apache.nifi.serialization.record.RecordSchema
-import org.geomesa.nifi.datastore.processor.mixins.DataStoreProcessor
 import org.geomesa.nifi.datastore.processor.records.Properties.GeometrySerializationDefaultWkt
 import org.geomesa.nifi.datastore.processor.records.{Expressions, GeometryEncoding, SimpleFeatureConverterOptions, SimpleFeatureRecordConverter}
+import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
 import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
 import org.geotools.data._
 import org.locationtech.geomesa.kafka.consumer.BatchConsumer.BatchResult
@@ -122,7 +122,7 @@ class GetGeoMesaKafkaRecord extends AbstractProcessor {
 
     val ds = {
       val props = {
-        val base = DataStoreProcessor.getDataStoreParams(context, descriptors)
+        val base = GeoMesaDataStoreService.getDataStoreParams(context, descriptors)
         val offset = context.getProperty(InitialOffset).getValue
         // override/set auto.offset.reset
         val config = KafkaDataStoreParams.ConsumerConfig.lookupOpt(base.asJava).getOrElse(new Properties())

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/KafkaDataStoreService.scala
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/KafkaDataStoreService.scala
@@ -1,0 +1,34 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.processors.kafka
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+import org.apache.nifi.components.PropertyDescriptor
+import org.apache.nifi.context.PropertyContext
+import org.apache.nifi.controller.ConfigurationContext
+import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
+import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
+import org.locationtech.geomesa.kafka.data.KafkaDataStoreParams.{ProducerConfig, TopicPartitions, TopicReplication}
+import org.locationtech.geomesa.kafka.data.{KafkaDataStoreFactory, KafkaDataStoreParams}
+
+@Tags(Array("geomesa", "geotools", "geo", "kafka"))
+@CapabilityDescription("Service for connecting to GeoMesa Kafka stores")
+class KafkaDataStoreService
+    extends GeoMesaDataStoreService[KafkaDataStoreFactory](KafkaDataStoreService.Properties) {
+  // set consumer count to zero to disable consuming
+  override protected def getDataStoreParams(context: PropertyContext): Map[String, _ <: AnyRef] =
+    super.getDataStoreParams(context) ++ Map(KafkaDataStoreParams.ConsumerCount.getName -> Int.box(0))
+}
+
+object KafkaDataStoreService extends PropertyDescriptorUtils {
+  // note: KafkaDataStoreFactory.ParameterInfo is consumer-oriented, but we want producer properties here
+  val Properties: Seq[PropertyDescriptor] =
+    createPropertyDescriptors(KafkaDataStoreFactory) ++
+        Seq(ProducerConfig, TopicPartitions, TopicReplication).map(createPropertyDescriptor)
+}

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/KafkaProcessor.scala
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/KafkaProcessor.scala
@@ -9,12 +9,12 @@
 package org.geomesa.nifi.processors.kafka
 
 import org.apache.nifi.processor.ProcessContext
-import org.geomesa.nifi.datastore.processor.mixins.DataStoreProcessor
+import org.geomesa.nifi.datastore.processor.mixins.AbstractDataStoreProcessor
 import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
 import org.locationtech.geomesa.kafka.data.KafkaDataStoreParams.{ProducerConfig, TopicPartitions, TopicReplication}
 import org.locationtech.geomesa.kafka.data.{KafkaDataStoreFactory, KafkaDataStoreParams}
 
-abstract class KafkaProcessor extends DataStoreProcessor(KafkaProcessor.KafkaProperties) {
+abstract class KafkaProcessor extends AbstractDataStoreProcessor(KafkaProcessor.KafkaProperties) {
   // set consumer count to zero to disable consuming
   override protected def getDataStoreParams(context: ProcessContext): Map[String, _] =
     super.getDataStoreParams(context) ++ Map(KafkaDataStoreParams.ConsumerCount.getName -> Int.box(0))

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/PutGeoMesaKafka.scala
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/PutGeoMesaKafka.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.kafka
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.ConverterIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{ConverterIngestProcessor, PutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "convert", "kafka", "stream", "streaming", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[KafkaDataStoreService], classOf[PutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaKafka extends KafkaProcessor with ConverterIngestProcessor

--- a/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/PutGeoMesaKafkaRecord.scala
+++ b/geomesa-kafka-bundle/geomesa-kafka-processors/src/main/scala/org/geomesa/nifi/processors/kafka/PutGeoMesaKafkaRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.kafka
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{PutGeoMesaRecord, RecordIngestProcessor}
 
 @Tags(Array("geomesa", "geo", "ingest", "records", "kafka", "stream", "streaming", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[KafkaDataStoreService], classOf[PutGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaKafkaRecord extends KafkaProcessor with RecordIngestProcessor

--- a/geomesa-lambda-bundle/geomesa-lambda-nar/pom.xml
+++ b/geomesa-lambda-bundle/geomesa-lambda-nar/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.geomesa.nifi</groupId>
+        <artifactId>geomesa-lambda-bundle</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>geomesa-lambda-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <description>GeoMesa Lambda Processor nar</description>
+
+    <dependencies>
+        <!-- nars are allowed to depend on at most 1 nar, which will act as a 'parent' and share its
+             classpath at runtime. see https://nifi.apache.org/docs/nifi-docs/html/developer-guide.html#nars -->
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api-nar</artifactId>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-lambda-processors</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.typesafe.scala-logging</groupId>
+                    <artifactId>scala-logging_${scala.binary.version}</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-nar-maven-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/geomesa-lambda-bundle/geomesa-lambda-processors/pom.xml
+++ b/geomesa-lambda-bundle/geomesa-lambda-processors/pom.xml
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.geomesa.nifi</groupId>
+        <artifactId>geomesa-lambda-bundle</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>geomesa-lambda-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <description>GeoMesa Lambda DataStore processor implementations</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-processors</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-lambda-datastore_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude geomesa-accumulo-datastore as we use the data store service instead -->
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-accumulo-datastore_${scala.binary.version}</artifactId>
+                </exclusion>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-all_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-arrow-gt_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-metrics-core_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-main</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-opengis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-cql</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-metadata</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-render</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.jts</groupId>
+                    <artifactId>jts-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-reflect</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.typesafe.scala-logging</groupId>
+                    <artifactId>scala-logging_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <!-- provided dependencies inherited from our parent nar -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-avro-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
+        </dependency>
+
+        <!-- test -->
+
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-kafka-datastore_${scala.binary.version}</artifactId>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-services</artifactId>
+            <version>${nifi.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/geomesa-lambda-bundle/geomesa-lambda-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-lambda-bundle/geomesa-lambda-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,1 @@
+org.geomesa.nifi.processors.lambda.LambdaDataStoreService

--- a/geomesa-lambda-bundle/geomesa-lambda-processors/src/main/scala/org/geomesa/nifi/processors/lambda/LambdaDataStoreService.scala
+++ b/geomesa-lambda-bundle/geomesa-lambda-processors/src/main/scala/org/geomesa/nifi/processors/lambda/LambdaDataStoreService.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2013-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0 which
+ * accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ */
+
+package org.geomesa.nifi.processors.lambda
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+import org.apache.nifi.components.PropertyDescriptor
+import org.apache.nifi.context.PropertyContext
+import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
+import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
+import org.geomesa.nifi.datastore.services.DataStoreService
+import org.geotools.data.DataStore
+import org.locationtech.geomesa.lambda.data.LambdaDataStore.LambdaConfig
+import org.locationtech.geomesa.lambda.data.{LambdaDataStore, LambdaDataStoreFactory, LambdaDataStoreParams}
+import org.locationtech.geomesa.utils.io.CloseWithLogging
+
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
+
+@Tags(Array("geomesa", "geotools", "geo", "kafka"))
+@CapabilityDescription("Service for connecting to GeoMesa Lambda stores")
+class LambdaDataStoreService
+    extends GeoMesaDataStoreService[LambdaDataStoreFactory](LambdaDataStoreService.Properties) {
+
+  import LambdaDataStoreService.DataStoreService
+
+  import scala.collection.JavaConverters._
+
+  override protected def getDataStoreParams(context: PropertyContext): Map[String, _ <: AnyRef] = {
+    super.getDataStoreParams(context) ++
+        Option(context.getProperty(DataStoreService))
+          .map(p => DataStoreService.getName -> p.asControllerService(classOf[DataStoreService]))
+          .toMap
+  }
+
+  override protected def tryGetDataStore(params: java.util.Map[String, AnyRef]): Try[DataStore] = {
+    var persistence: DataStore = null
+    var config: LambdaConfig = null
+    try {
+      val controller = params.get(DataStoreService.getName).asInstanceOf[DataStoreService]
+      if (controller == null) {
+        throw new IllegalArgumentException("Could not load datastore using provided parameters")
+      }
+      persistence = controller.loadDataStore()
+      if (persistence == null) {
+        throw new IllegalArgumentException(
+          s"Could not load datastore from controller service ${controller.getClass.getName}")
+      }
+      val catalog = controller.getDataStoreParams.asScala.collectFirst {
+        case (k, v: String) if k.contains("catalog") => v
+      }
+      config = LambdaDataStoreParams.parse(params, catalog.getOrElse("nifi"))
+      Success(new LambdaDataStore(persistence, config))
+    } catch {
+      case NonFatal(e) =>
+        if (config != null) {
+          CloseWithLogging(config.offsetManager)
+        }
+        if (persistence != null) {
+          CloseWithLogging(persistence)
+        }
+        Failure(e)
+    }
+  }
+}
+
+object LambdaDataStoreService extends PropertyDescriptorUtils {
+
+  import org.locationtech.geomesa.lambda.data.LambdaDataStoreParams._
+
+  val DataStoreService: PropertyDescriptor =
+    new PropertyDescriptor.Builder()
+        .name("DataStoreService")
+        .displayName("DataStore Service")
+        .required(true)
+        .description("The DataStore to use for long-term persistence")
+        .identifiesControllerService(classOf[DataStoreService])
+        .build()
+
+  // note: LambdaDataStoreFactory.ParameterInfo has Accumulo connection params, but we allow any store
+  val Properties: Seq[PropertyDescriptor] =
+    Seq(DataStoreService) ++ Seq(
+      BrokersParam,
+      ZookeepersParam,
+      ExpiryParam,
+      PersistParam,
+      ProducerOptsParam,
+      ConsumerOptsParam,
+      ConsumersParam,
+      PartitionsParam,
+      QueryThreadsParam,
+      QueryTimeoutParam,
+      GenerateStatsParam,
+      AuditQueriesParam,
+      LooseBBoxParam,
+      AuthsParam,
+      ForceEmptyAuthsParam
+    ).map(createPropertyDescriptor)
+}

--- a/geomesa-lambda-bundle/pom.xml
+++ b/geomesa-lambda-bundle/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.geomesa.nifi</groupId>
+        <artifactId>geomesa-nifi</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>geomesa-lambda-bundle</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>geomesa-lambda-nar</module>
+        <module>geomesa-lambda-processors</module>
+    </modules>
+
+</project>

--- a/geomesa-redis-bundle/geomesa-redis-nar/pom.xml
+++ b/geomesa-redis-bundle/geomesa-redis-nar/pom.xml
@@ -27,10 +27,9 @@
             <artifactId>geomesa-redis-processors</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.locationtech.geomesa</groupId>
-            <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
-            <classifier>data</classifier>
-            <version>${geomesa.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/geomesa-redis-bundle/geomesa-redis-processors/pom.xml
+++ b/geomesa-redis-bundle/geomesa-redis-processors/pom.xml
@@ -15,6 +15,13 @@
     <description>GeoMesa Redis processor implementations</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.geomesa.nifi</groupId>
+            <artifactId>geomesa-datastore-services-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.geomesa.nifi</groupId>
             <artifactId>geomesa-datastore-processors</artifactId>
@@ -23,6 +30,123 @@
         <dependency>
             <groupId>org.locationtech.geomesa</groupId>
             <artifactId>geomesa-redis-datastore_${scala.binary.version}</artifactId>
+            <exclusions>
+                <!-- exclude dependencies provided by datastore-services-api-nar -->
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-filter_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-kryo_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-feature-avro_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-arrow-gt_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-z3_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-metrics-core_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.geomesa</groupId>
+                    <artifactId>geomesa-security_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-main</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-opengis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-cql</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-metadata</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>gt-render</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.locationtech.jts</groupId>
+                    <artifactId>jts-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- provided dependencies inherited from our parent nar -->
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-index-api_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.geomesa</groupId>
+            <artifactId>geomesa-convert-all_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-avro-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
         </dependency>
 
         <!-- test -->

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,1 @@
+org.geomesa.nifi.processors.redis.RedisDataStoreService

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -2,3 +2,8 @@ org.geomesa.nifi.processors.redis.AvroToPutGeoMesaRedis
 org.geomesa.nifi.processors.redis.PutGeoMesaRedis
 org.geomesa.nifi.processors.redis.PutGeoMesaRedisRecord
 org.geomesa.nifi.processors.redis.UpdateGeoMesaRedisRecord
+org.geomesa.nifi.datastore.processor.ConvertToGeoAvro
+org.geomesa.nifi.datastore.processor.geotools.AvroToPutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoTools
+org.geomesa.nifi.datastore.processor.geotools.PutGeoToolsRecord
+org.geomesa.nifi.datastore.processor.geotools.UpdateGeoToolsRecord

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/AvroToPutGeoMesaRedis.scala
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/AvroToPutGeoMesaRedis.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.redis
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.AvroIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{AvroIngestProcessor, AvroToPutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "avro", "redis", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[RedisDataStoreService], classOf[AvroToPutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class AvroToPutGeoMesaRedis extends RedisProcessor with AvroIngestProcessor

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/PutGeoMesaRedis.scala
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/PutGeoMesaRedis.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.redis
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.ConverterIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{ConverterIngestProcessor, PutGeoMesa}
 
 @Tags(Array("geomesa", "geo", "ingest", "convert", "redis", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[RedisDataStoreService], classOf[PutGeoMesa]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaRedis extends RedisProcessor with ConverterIngestProcessor

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/PutGeoMesaRedisRecord.scala
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/PutGeoMesaRedisRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.redis
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordIngestProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{PutGeoMesaRecord, RecordIngestProcessor}
 
 @Tags(Array("geomesa", "geo", "ingest", "records", "redis", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[RedisDataStoreService], classOf[PutGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class PutGeoMesaRedisRecord extends RedisProcessor with RecordIngestProcessor

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/RedisDataStoreService.scala
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/RedisDataStoreService.scala
@@ -1,0 +1,23 @@
+/***********************************************************************
+ * Copyright (c) 2015-2021 Commonwealth Computer Research, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution and is available at
+ * http://www.opensource.org/licenses/apache2.0.php.
+ ***********************************************************************/
+
+package org.geomesa.nifi.processors.redis
+
+import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
+import org.apache.nifi.components.PropertyDescriptor
+import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
+import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
+import org.locationtech.geomesa.redis.data.RedisDataStoreFactory
+
+@Tags(Array("geomesa", "geotools", "geo", "redis"))
+@CapabilityDescription("Service for connecting to GeoMesa Redis stores")
+class RedisDataStoreService extends GeoMesaDataStoreService[RedisDataStoreFactory](RedisDataStoreService.Properties)
+
+object RedisDataStoreService extends PropertyDescriptorUtils {
+  val Properties: Seq[PropertyDescriptor] = createPropertyDescriptors(RedisDataStoreFactory)
+}

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/RedisProcessor.scala
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/RedisProcessor.scala
@@ -8,11 +8,11 @@
 
 package org.geomesa.nifi.processors.redis
 
-import org.geomesa.nifi.datastore.processor.mixins.DataStoreProcessor
+import org.geomesa.nifi.datastore.processor.mixins.AbstractDataStoreProcessor
 import org.geomesa.nifi.datastore.processor.utils.PropertyDescriptorUtils
 import org.locationtech.geomesa.redis.data.RedisDataStoreFactory
 
-abstract class RedisProcessor extends DataStoreProcessor(RedisProcessor.RedisProperties)
+abstract class RedisProcessor extends AbstractDataStoreProcessor(RedisProcessor.RedisProperties)
 
 object RedisProcessor extends PropertyDescriptorUtils {
   private val RedisProperties = createPropertyDescriptors(RedisDataStoreFactory)

--- a/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/UpdateGeoMesaRedisRecord.scala
+++ b/geomesa-redis-bundle/geomesa-redis-processors/src/main/scala/org/geomesa/nifi/processors/redis/UpdateGeoMesaRedisRecord.scala
@@ -8,8 +8,11 @@
 
 package org.geomesa.nifi.processors.redis
 
-import org.apache.nifi.annotation.documentation.Tags
-import org.geomesa.nifi.datastore.processor.RecordUpdateProcessor
+import org.apache.nifi.annotation.documentation.{DeprecationNotice, Tags}
+import org.geomesa.nifi.datastore.processor.{RecordUpdateProcessor, UpdateGeoMesaRecord}
 
 @Tags(Array("geomesa", "geo", "update", "records", "redis", "geotools"))
+@DeprecationNotice(
+  alternatives = Array(classOf[RedisDataStoreService], classOf[UpdateGeoMesaRecord]),
+  reason = "Replaced with controller service for data store connections")
 class UpdateGeoMesaRedisRecord extends RedisProcessor with RecordUpdateProcessor

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <module>geomesa-fs-bundle</module>
         <module>geomesa-hbase-bundle</module>
         <module>geomesa-kafka-bundle</module>
+        <module>geomesa-lambda-bundle</module>
         <module>geomesa-redis-bundle</module>
     </modules>
 
@@ -85,6 +86,8 @@
         <specs2.version>4.3.2</specs2.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.5</slf4j.version>
+        <log4j.version>1.2.17</log4j.version>
+        <scalalogging.version>3.8.0</scalalogging.version>
         <maven.test.jvmargs>-Xms512m -Xmx4g -XX:-UseGCOverheadLimit</maven.test.jvmargs>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -102,29 +105,9 @@
             <!-- Nifi Dependencies -->
             <dependency>
                 <groupId>org.apache.nifi</groupId>
-                <artifactId>nifi-api</artifactId>
-                <version>${nifi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.nifi</groupId>
-                <artifactId>nifi-utils</artifactId>
-                <version>${nifi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.nifi</groupId>
-                <artifactId>nifi-processor-utils</artifactId>
-                <version>${nifi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-services-api-nar</artifactId>
                 <version>${nifi.version}</version>
                 <type>nar</type>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.nifi</groupId>
-                <artifactId>nifi-aws-service-api</artifactId>
-                <version>${nifi.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
@@ -134,28 +117,63 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-api</artifactId>
+                <version>${nifi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-utils</artifactId>
+                <version>${nifi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-processor-utils</artifactId>
+                <version>${nifi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-aws-service-api</artifactId>
+                <version>${nifi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-record</artifactId>
                 <version>${nifi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-avro-record-utils</artifactId>
+                <version>${nifi.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-record-serialization-service-api</artifactId>
                 <version>${nifi.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-record-sink-api</artifactId>
                 <version>${nifi.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-record-utils</artifactId>
                 <version>${nifi.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-schema-registry-service-api</artifactId>
                 <version>${nifi.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
@@ -181,6 +199,11 @@
 
             <dependency>
                 <groupId>org.geomesa.nifi</groupId>
+                <artifactId>geomesa-datastore-services-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geomesa.nifi</groupId>
                 <artifactId>geomesa-accumulo-processors</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -195,11 +218,6 @@
                 <artifactId>geomesa-accumulo2-nar</artifactId>
                 <version>${project.version}</version>
                 <type>nar</type>
-            </dependency>
-            <dependency>
-                <groupId>org.geomesa.nifi</groupId>
-                <artifactId>geomesa-datastore-services-api</artifactId>
-                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.geomesa.nifi</groupId>
@@ -264,6 +282,17 @@
             </dependency>
             <dependency>
                 <groupId>org.geomesa.nifi</groupId>
+                <artifactId>geomesa-lambda-processors</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geomesa.nifi</groupId>
+                <artifactId>geomesa-lambda-nar</artifactId>
+                <version>${project.version}</version>
+                <type>nar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.geomesa.nifi</groupId>
                 <artifactId>geomesa-redis-processors</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -289,6 +318,16 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-utils_${scala.binary.version}</artifactId>
+                <version>${geomesa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
+                <artifactId>geomesa-process-vector_${scala.binary.version}</artifactId>
+                <version>${geomesa.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.locationtech.geomesa</groupId>
                 <artifactId>geomesa-tools_${scala.binary.version}</artifactId>
                 <version>${geomesa.version}</version>
             </dependency>
@@ -300,12 +339,12 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-fs-datastore_${scala.binary.version}</artifactId>
                 <version>${geomesa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-kafka_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-hbase-datastore_${scala.binary.version}</artifactId>
                 <version>${geomesa.version}</version>
             </dependency>
             <dependency>
@@ -315,18 +354,24 @@
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-fs-datastore_${scala.binary.version}</artifactId>
-                <version>${geomesa.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.locationtech.geomesa</groupId>
-                <artifactId>geomesa-fs-tools_${scala.binary.version}</artifactId>
+                <artifactId>geomesa-lambda-datastore_${scala.binary.version}</artifactId>
                 <version>${geomesa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.geomesa</groupId>
                 <artifactId>geomesa-redis-datastore_${scala.binary.version}</artifactId>
                 <version>${geomesa.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-main</artifactId>
+                <version>${gt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-render</artifactId>
+                <version>${gt.version}</version>
             </dependency>
 
             <!-- data store dependencies -->
@@ -390,13 +435,11 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${hadoop.version}</version>
-                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-client</artifactId>
                 <version>${hadoop.version}</version>
-                <scope>compile</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.mortbay.jetty</groupId>
@@ -448,7 +491,6 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-aws</artifactId>
                 <version>${hadoop.version}</version>
-                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -526,6 +568,12 @@
                 <version>2.8.6</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>28.0-jre</version>
+            </dependency>
+
             <!-- Netty 4.x used by arrow, hadoop, hbase, and c* -->
             <dependency>
                 <groupId>io.netty</groupId>
@@ -570,6 +618,24 @@
                 <version>3.6.2.Final</version>
             </dependency>
 
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.9.3</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-configuration</groupId>
+                <artifactId>commons-configuration</artifactId>
+                <version>1.6</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- exclude commons-beanutils-core, which doesn't exist in 1.9.3 -->
+                        <groupId>commons-beanutils</groupId>
+                        <artifactId>commons-beanutils-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <!-- scala -->
 
             <dependency>
@@ -591,6 +657,11 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-reflect</artifactId>
                 <version>${scala.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.typesafe.scala-logging</groupId>
+                <artifactId>scala-logging_${scala.binary.version}</artifactId>
+                <version>${scalalogging.version}</version>
             </dependency>
 
             <!-- test dependencies -->
@@ -622,6 +693,12 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -792,7 +869,7 @@
                 <plugin>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-nar-maven-plugin</artifactId>
-                    <version>1.2.0</version>
+                    <version>1.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>


### PR DESCRIPTION
* Nar inter-dependencies have been fixed, making most nars much smaller
* Core geomesa jars moved to geomesa-datastore-services-api-nar for inheritance
* New agnostic processors with data stores exposed via controller service
** Old data-store-specific processors are deprecated
* New Lambda data store processor