### PR TITLE
GEOMESA-3287 Fix JDBC connection re-load

### DIFF
--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesa.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesa.scala
@@ -19,7 +19,7 @@ import org.apache.nifi.processor._
 import org.geomesa.nifi.datastore.processor.CompatibilityMode.CompatibilityMode
 import org.geomesa.nifi.datastore.processor.mixins.ConvertInputProcessor.ConverterCallback
 import org.geomesa.nifi.datastore.processor.mixins.{ConvertInputProcessor, DataStoreIngestProcessor, FeatureWriters}
-import org.geotools.data._
+import org.geomesa.nifi.datastore.services.DataStoreService
 import org.locationtech.geomesa.utils.geotools.{SftArgResolver, SftArgs}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
@@ -50,10 +50,10 @@ class PutGeoMesa extends DataStoreIngestProcessor with ConvertInputProcessor {
 
   override protected def createIngest(
       context: ProcessContext,
-      dataStore: DataStore,
+      service: DataStoreService,
       writers: FeatureWriters,
       mode: CompatibilityMode): IngestProcessor = {
-    val ingest = new ConverterIngest(dataStore, writers, mode)
+    val ingest = new ConverterIngest(service, writers, mode)
     // due to validation, should be all Rights
     ingest.init(PutGeoMesa.initSchemas(context).map { case Right(sft) => sft })
     ingest
@@ -65,12 +65,12 @@ class PutGeoMesa extends DataStoreIngestProcessor with ConvertInputProcessor {
   /**
    * Converter ingest
    *
-   * @param store data store
+   * @param service data store service
    * @param writers feature writers
    * @param mode schema compatibility mode
    */
-  class ConverterIngest(store: DataStore, writers: FeatureWriters, mode: CompatibilityMode)
-      extends IngestProcessor(store, writers, mode) {
+  class ConverterIngest(service: DataStoreService, writers: FeatureWriters, mode: CompatibilityMode)
+      extends IngestProcessor(service, writers, mode) {
 
     def init(sfts: Seq[SimpleFeatureType]): Unit = sfts.foreach(checkSchema)
 

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesaRecord.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/PutGeoMesaRecord.scala
@@ -22,6 +22,7 @@ import org.geomesa.nifi.datastore.processor.PutGeoMesaRecord.CountHolder
 import org.geomesa.nifi.datastore.processor.mixins.{DataStoreIngestProcessor, FeatureWriters}
 import org.geomesa.nifi.datastore.processor.records.Properties._
 import org.geomesa.nifi.datastore.processor.records.{GeometryEncoding, OptionExtractor, SimpleFeatureRecordConverter}
+import org.geomesa.nifi.datastore.services.DataStoreService
 import org.geotools.data._
 import org.locationtech.geomesa.utils.io.WithClose
 
@@ -47,29 +48,29 @@ class PutGeoMesaRecord extends DataStoreIngestProcessor {
 
   override protected def createIngest(
       context: ProcessContext,
-      dataStore: DataStore,
+      service: DataStoreService,
       writers: FeatureWriters,
       mode: CompatibilityMode): IngestProcessor = {
     val factory = context.getProperty(RecordReader).asControllerService(classOf[RecordReaderFactory])
     val options = OptionExtractor(context, GeometryEncoding.Wkt)
-    new RecordIngest(dataStore, writers, factory, options, mode)
+    new RecordIngest(service, writers, factory, options, mode)
   }
 
   /**
    * Record based ingest
    *
-   * @param store data store
+   * @param service data store service
    * @param writers feature writers
    * @param recordReaderFactory record reader factory
    * @param options converter options
    */
   class RecordIngest(
-      store: DataStore,
+      service: DataStoreService,
       writers: FeatureWriters,
       recordReaderFactory: RecordReaderFactory,
       options: OptionExtractor,
       mode: CompatibilityMode
-    ) extends IngestProcessor(store, writers, mode) {
+    ) extends IngestProcessor(service, writers, mode) {
 
     import scala.collection.JavaConverters._
 

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/DataStoreProcessor.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/DataStoreProcessor.scala
@@ -21,17 +21,14 @@ trait DataStoreProcessor extends BaseProcessor {
 
   import DataStoreProcessor.Properties.DataStoreService
 
-  import scala.collection.JavaConverters._
+  protected def getDataStoreService(context: ProcessContext): DataStoreService =
+    context.getProperty(DataStoreService).asControllerService(classOf[DataStoreService])
 
-  protected def loadDataStores(context: ProcessContext): Seq[DataStore] = {
-    val threads = math.max(context.getMaxConcurrentTasks, 1)
-    val service = context.getProperty(DataStoreService).asControllerService(classOf[DataStoreService])
-    service.loadDataStores(threads).asScala.toSeq
-  }
-
+  @deprecated
   protected def loadDataStore(context: ProcessContext): DataStore =
     context.getProperty(DataStoreService).asControllerService(classOf[DataStoreService]).loadDataStore()
 
+  @deprecated
   protected def disposeDataStore(ds: DataStore, context: Option[ProcessContext]): Unit = {
     context match {
       case Some(c) => c.getProperty(DataStoreService).asControllerService(classOf[DataStoreService]).dispose(ds)

--- a/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/FeatureWriters.scala
+++ b/geomesa-datastore-bundle/geomesa-datastore-processors/src/main/scala/org/geomesa/nifi/datastore/processor/mixins/FeatureWriters.scala
@@ -10,19 +10,20 @@ package org.geomesa.nifi.datastore.processor.mixins
 
 import com.github.benmanes.caffeine.cache.{CacheLoader, Caffeine, LoadingCache}
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig
+import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool, GenericObjectPoolConfig}
+import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
 import org.apache.nifi.flowfile.FlowFile
+import org.geomesa.nifi.datastore.services.DataStoreService
 import org.geotools.data.{DataStore, FeatureWriter, Transaction}
 import org.geotools.filter.text.ecql.ECQL
 import org.locationtech.geomesa.filter.FilterHelper
 import org.locationtech.geomesa.utils.geotools.FeatureUtils
-import org.locationtech.geomesa.utils.io.CloseablePool.CommonsPoolPool
-import org.locationtech.geomesa.utils.io.{CloseWithLogging, CloseablePool, WithClose}
+import org.locationtech.geomesa.utils.io.{CloseWithLogging, WithClose}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 
 import java.io.Closeable
-import java.util.Collections
 import java.util.concurrent.LinkedBlockingQueue
+import scala.util.control.NonFatal
 
 /**
  * Abstraction over feature writers
@@ -60,18 +61,42 @@ object FeatureWriters {
   /**
    * Create feature writers
    *
-   * @param stores data stores to use, one per thread
+   * @param service data store service to use
    * @param mode write mode
    * @param caching cache timeout in milliseconds, or None for no caching
    * @return
    */
-  def apply(stores: Seq[DataStore], mode: WriteMode, caching: Option[Long]): FeatureWriters = {
-    val queue = new LinkedBlockingQueue[DataStore](stores.asJava)
+  @deprecated("Use appender or modifier")
+  def apply(service: DataStoreService, mode: WriteMode, caching: Option[Long]): FeatureWriters = {
     mode match {
-      case WriteMode.Append => caching.map(new PooledWriters(queue, _)).getOrElse(new SingletonWriters(queue))
-      case WriteMode.Modify(attribute) => new ModifyWriters(queue, attribute, caching)
+      case WriteMode.Append => appender(service, caching)
+      case WriteMode.Modify(attribute) => modifier(service, attribute)
     }
   }
+
+  /**
+   * Gets an appending feature writer
+   *
+   * @param service data store service
+   * @param caching cache timeout in milliseconds, or None for no caching
+   * @return
+   */
+  def appender(service: DataStoreService, caching: Option[Long]): FeatureWriters = {
+    caching match {
+      case None => new SingletonWriters(service)
+      case Some(timeout) => new PooledWriters(service, timeout)
+    }
+  }
+
+  /**
+   * Gets a modifying feature writer
+   *
+   * @param service data store service
+   * @param attribute attribute used to finding features, or None to use feature ID
+   * @return
+   */
+  def modifier(service: DataStoreService, attribute: Option[String]): FeatureWriters =
+    new ModifyWriters(service, attribute)
 
   /**
    * Writes for simple features
@@ -83,7 +108,7 @@ object FeatureWriters {
    *
    * @param writer feature writer
    */
-  class AppendWriter(writer: FeatureWriter[SimpleFeatureType, SimpleFeature]) extends SimpleWriter {
+  private class AppendWriter(writer: FeatureWriter[SimpleFeatureType, SimpleFeature]) extends SimpleWriter {
     override def apply(f: SimpleFeature): Unit = FeatureUtils.write(writer, f)
     override def close(): Unit = CloseWithLogging(writer)
   }
@@ -95,25 +120,39 @@ object FeatureWriters {
    * @param typeName feature type name
    * @param attribute attribute to match, or None for feature id
    */
-  class ModifyWriter(ds: DataStore, typeName: String, attribute: Option[String], appender: SimpleWriter)
+  private class ModifyWriter(ds: DataStore, typeName: String, attribute: Option[String])
       extends SimpleWriter with LazyLogging  {
 
     import FilterHelper.ff
+
+    private[FeatureWriters] var invalid = false
 
     override def apply(f: SimpleFeature): Unit = {
       val filter = attribute match {
         case None    => ff.id(ff.featureId(f.getID))
         case Some(a) => ff.equals(ff.property(a), ff.literal(f.getAttribute(a)))
       }
-      WithClose(ds.getFeatureWriter(typeName, filter, Transaction.AUTO_COMMIT)) { writer =>
+      val writer = try {
+        ds.getFeatureWriter(typeName, filter, Transaction.AUTO_COMMIT)
+      } catch {
+        case NonFatal(e) =>
+          invalid = true
+          throw e
+      }
+      try {
         if (writer.hasNext) {
           FeatureUtils.write(writer, f, useProvidedFid = true)
           if (writer.hasNext) {
             logger.warn(s"Filter '${ECQL.toCQL(filter)}' matched multiple records, only updating the first one")
           }
         } else {
-          appender.apply(f)
+          logger.warn(s"Filter '${ECQL.toCQL(filter)}' did not match any records, applying as an insert")
+          WithClose(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT)) { writer =>
+            FeatureUtils.write(writer, f, useProvidedFid = true)
+          }
         }
+      } finally {
+        CloseWithLogging(writer)
       }
     }
 
@@ -123,15 +162,29 @@ object FeatureWriters {
   /**
    * Each flow file gets a new feature writer, which is closed after use
    *
-   * @param stores data stores
+   * @param service data store service
    */
-  class SingletonWriters(stores: LinkedBlockingQueue[DataStore]) extends FeatureWriters {
+  private class SingletonWriters(service: DataStoreService) extends FeatureWriters {
+
+    private val stores = new LinkedBlockingQueue[DataStore]()
 
     override def borrow[T](typeName: String, file: FlowFile)(fn: SimpleWriter => T): T = {
-      val ds = stores.poll()
+      val ds = stores.poll() match {
+        case null => service.loadDataStore()
+        case ds => ds
+      }
+      // if we can't get the writer, that usually means the datastore has become invalid
+      val writer = try {
+        new AppendWriter(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT))
+      } catch {
+        case NonFatal(e) =>
+          service.dispose(ds)
+          throw e
+      }
       try {
-        WithClose(new AppendWriter(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT)))(fn)
+        fn(writer)
       } finally {
+        CloseWithLogging(writer)
         stores.put(ds)
       }
     }
@@ -143,84 +196,127 @@ object FeatureWriters {
   /**
    * Pooled feature writers, re-used between flow files
    *
-   * @param stores data stores
+   * @param service data store service
    */
-  class PooledWriters(stores: LinkedBlockingQueue[DataStore], timeout: Long) extends FeatureWriters {
+  private class PooledWriters(service: DataStoreService, timeout: Long) extends FeatureWriters {
 
-    private val caches: Map[DataStore, LoadingCache[String, CloseablePool[SimpleWriter]]] = {
-      val seq = stores.asScala.map { ds =>
-        ds -> Caffeine.newBuilder().build[String, CloseablePool[SimpleWriter]](
-          new CacheLoader[String, CloseablePool[SimpleWriter]] {
-            override def load(key: String): CloseablePool[SimpleWriter] = {
-              val config = new GenericObjectPoolConfig[SimpleWriter]()
-              config.setMaxTotal(-1)
-              config.setMaxIdle(-1)
-              config.setMinIdle(0)
-              config.setMinEvictableIdleTimeMillis(timeout)
-              config.setTimeBetweenEvictionRunsMillis(math.max(1000, timeout / 5))
-              config.setNumTestsPerEvictionRun(10)
-
-              new CommonsPoolPool(new AppendWriter(ds.getFeatureWriterAppend(key, Transaction.AUTO_COMMIT)), config)
-            }
-          }
-        )
-      }
-      seq.toMap
-    }
+    private val stores = new LinkedBlockingQueue[(DataStore, LoadingCache[String, AppendWriterPool])]()
 
     override def borrow[T](typeName: String, file: FlowFile)(fn: SimpleWriter => T): T = {
-      val ds = stores.poll()
+      val (ds, cache) = stores.poll() match {
+        case null =>
+          val ds = service.loadDataStore()
+          val cache = Caffeine.newBuilder().build[String, AppendWriterPool](
+            new CacheLoader[String, AppendWriterPool] {
+              override def load(key: String): AppendWriterPool = new AppendWriterPool(ds, key, timeout)
+            })
+          (ds, cache)
+
+        case dsAndCache => dsAndCache
+      }
+      val pool = cache.get(typeName)
+      // if we can't get the writer, that usually means the datastore has become invalid
+      val writer = try {
+        pool.borrow()
+      } catch {
+        case NonFatal(e) =>
+          cache.invalidate(typeName)
+          CloseWithLogging(pool)
+          service.dispose(ds)
+          throw e
+      }
+
       try {
-        caches(ds).get(typeName).borrow(fn)
+        fn(writer)
       } finally {
-        stores.put(ds)
+        pool.returnIt(writer)
+        stores.put(ds -> cache)
       }
     }
 
     override def invalidate(typeName: String): Unit = {
-      caches.foreach { case (_, cache) =>
-        val cur = cache.get(typeName)
-        cache.invalidate(typeName)
-        CloseWithLogging(cur)
+      stores.iterator().asScala.foreach { case (_, cache) =>
+        val cur = cache.getIfPresent(typeName)
+        if (cur != null) {
+          cache.invalidate(typeName)
+          CloseWithLogging(cur)
+        }
+
       }
     }
 
-    override def close(): Unit = caches.foreach { case (_, c) => CloseWithLogging(c.asMap().asScala.values) }
+    override def close(): Unit = {
+      stores.iterator().asScala.foreach { case (ds, cache) =>
+        CloseWithLogging(cache.asMap().asScala.values)
+        service.dispose(ds)
+      }
+    }
   }
 
   /**
    * Each record gets an updating writer
    *
-   * @param stores datastores
+   * @param service datastore service
    * @param attribute the unique attribute used to identify the record to update
    */
-  class ModifyWriters(stores: LinkedBlockingQueue[DataStore], attribute: Option[String], caching: Option[Long])
+  private class ModifyWriters(service: DataStoreService, attribute: Option[String])
       extends FeatureWriters {
 
-    private val appenders: Map[DataStore, FeatureWriters] = {
-      val seq = stores.asScala.map { ds =>
-        val queue = new LinkedBlockingQueue(Collections.singleton(ds))
-        val appender = caching match {
-          case None => new SingletonWriters(queue)
-          case Some(timeout) => new PooledWriters(queue, timeout)
-        }
-        ds -> appender
-      }
-      seq.toMap
-    }
+    private val stores = new LinkedBlockingQueue[DataStore]()
 
     override def borrow[T](typeName: String, file: FlowFile)(fn: SimpleWriter => T): T = {
-      val ds = stores.poll()
+      val ds = stores.poll() match {
+        case null => service.loadDataStore()
+        case ds => ds
+      }
+      val writer = new ModifyWriter(ds, typeName, attribute)
       try {
-        appenders(ds).borrow(typeName, file) { appender =>
-          WithClose(new ModifyWriter(ds, typeName, attribute, appender))(fn)
-        }
+        fn(writer)
       } finally {
-        stores.put(ds)
+        CloseWithLogging(writer)
+        if (writer.invalid) {
+          service.dispose(ds)
+        } else {
+          stores.put(ds)
+        }
       }
     }
 
-    override def invalidate(typeName: String): Unit = appenders.values.foreach(_.invalidate(typeName))
-    override def close(): Unit = CloseWithLogging(appenders.values)
+    override def invalidate(typeName: String): Unit = {}
+    override def close(): Unit = stores.iterator().asScala.foreach(service.dispose)
+  }
+
+  /**
+   * Pool for append writers
+   *
+   * @param ds data store
+   * @param typeName feature type
+   * @param timeout writer timeout/refresh
+   */
+  private class AppendWriterPool(ds: DataStore, typeName: String, timeout: Long) extends Closeable {
+
+    private val factory: BasePooledObjectFactory[AppendWriter] = new BasePooledObjectFactory[AppendWriter] {
+      override def wrap(obj: AppendWriter) = new DefaultPooledObject[AppendWriter](obj)
+      override def create(): AppendWriter = new AppendWriter(ds.getFeatureWriterAppend(typeName, Transaction.AUTO_COMMIT))
+      override def destroyObject(p: PooledObject[AppendWriter]): Unit = p.getObject.close()
+    }
+
+    private val config = {
+      val config = new GenericObjectPoolConfig[AppendWriter]()
+      config.setMaxTotal(-1)
+      config.setMaxIdle(-1)
+      config.setMinIdle(0)
+      config.setMinEvictableIdleTimeMillis(timeout)
+      config.setTimeBetweenEvictionRunsMillis(math.max(1000, timeout / 5))
+      config.setNumTestsPerEvictionRun(10)
+      config
+    }
+
+    private val pool = new GenericObjectPool[AppendWriter](factory, config)
+
+    def borrow(): AppendWriter = pool.borrowObject()
+    def returnIt(writer: AppendWriter): Unit = pool.returnObject(writer)
+
+    override def close(): Unit = pool.close()
   }
 }

--- a/geomesa-datastore-bundle/geomesa-datastore-services-api/src/main/java/org/geomesa/nifi/datastore/services/DataStoreService.java
+++ b/geomesa-datastore-bundle/geomesa-datastore-services-api/src/main/java/org/geomesa/nifi/datastore/services/DataStoreService.java
@@ -11,30 +11,7 @@ package org.geomesa.nifi.datastore.services;
 import org.apache.nifi.controller.ControllerService;
 import org.geotools.data.DataStore;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public interface DataStoreService extends ControllerService {
-
-    /**
-     * Load multiple data stores at once for use in multiple threads. The default
-     * implementation assumes data stores are thread safe and just returns a single instance
-     * multiple times.
-     *
-     * @param count number of stores to load, must be positive
-     * @return list of data stores
-     */
-    default List<DataStore> loadDataStores(int count) {
-        if (count < 1) {
-            throw new IllegalArgumentException("Count must be > 0: " + count);
-        }
-        DataStore store = loadDataStore();
-        List<DataStore> list = new ArrayList<>(count);
-        for (int i = 0; i < count; i ++) {
-            list.add(store);
-        }
-        return list;
-    }
 
     DataStore loadDataStore();
 

--- a/geomesa-gt-bundle/geomesa-gt-processors/src/main/scala/org/geomesa/nifi/processors/gt/PartitionedPostgisDataStoreService.scala
+++ b/geomesa-gt-bundle/geomesa-gt-processors/src/main/scala/org/geomesa/nifi/processors/gt/PartitionedPostgisDataStoreService.scala
@@ -9,14 +9,12 @@
 package org.geomesa.nifi.processors.gt
 
 import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
-import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
 import org.locationtech.geomesa.gt.partition.postgis.PartitionedPostgisDataStoreFactory
 
 @Tags(Array("geomesa", "geotools", "geo", "postgis"))
 @CapabilityDescription("Service for connecting to GeoMesa partitioned PostGIS stores")
 class PartitionedPostgisDataStoreService
-    extends GeoMesaDataStoreService[PartitionedPostgisDataStoreFactory](PartitionedPostgisDataStoreService.Parameters)
-        with JdbcDataStoreService
+    extends JdbcDataStoreService[PartitionedPostgisDataStoreFactory](PartitionedPostgisDataStoreService.Parameters)
 
 object PartitionedPostgisDataStoreService extends JdbcPropertyDescriptorUtils {
   private val Parameters = createPropertyDescriptors(new PartitionedPostgisDataStoreFactory().getParametersInfo.toSeq)

--- a/geomesa-gt-bundle/geomesa-gt-processors/src/main/scala/org/geomesa/nifi/processors/gt/PostgisDataStoreService.scala
+++ b/geomesa-gt-bundle/geomesa-gt-processors/src/main/scala/org/geomesa/nifi/processors/gt/PostgisDataStoreService.scala
@@ -9,14 +9,12 @@
 package org.geomesa.nifi.processors.gt
 
 import org.apache.nifi.annotation.documentation.{CapabilityDescription, Tags}
-import org.geomesa.nifi.datastore.processor.service.GeoMesaDataStoreService
 import org.geotools.data.postgis.PostgisNGDataStoreFactory
 
 @Tags(Array("geomesa", "geotools", "geo", "postgis"))
 @CapabilityDescription("Service for connecting to PostGIS stores")
 class PostgisDataStoreService
-    extends GeoMesaDataStoreService[PostgisNGDataStoreFactory](PostgisDataStoreService.Parameters)
-        with JdbcDataStoreService
+    extends JdbcDataStoreService[PostgisNGDataStoreFactory](PostgisDataStoreService.Parameters)
 
 object PostgisDataStoreService extends JdbcPropertyDescriptorUtils {
   private val Parameters = createPropertyDescriptors(new PostgisNGDataStoreFactory().getParametersInfo.toSeq)

--- a/geomesa-gt-bundle/geomesa-gt-processors/src/test/scala/org/geomesa/nifi/processors/gt/PutGeoMesaPostgisTest.scala
+++ b/geomesa-gt-bundle/geomesa-gt-processors/src/test/scala/org/geomesa/nifi/processors/gt/PutGeoMesaPostgisTest.scala
@@ -124,7 +124,9 @@ class PutGeoMesaPostgisTest extends Specification with BeforeAfterAll with LazyL
       try {
         configurePostgisService(runner)
         val service = runner.getControllerService[DataStoreService]("data-store", classOf[DataStoreService])
-        val Array(store1, store2, store3) = service.loadDataStores(3).toArray(Array.empty[DataStore])
+        val store1 = service.loadDataStore()
+        val store2 = service.loadDataStore()
+        val store3 = service.loadDataStore()
         try {
           store1 must not(be(store2))
           store2 must not(be(store3))

--- a/geomesa-lambda-bundle/geomesa-lambda-processors/src/main/scala/org/geomesa/nifi/processors/lambda/LambdaDataStoreService.scala
+++ b/geomesa-lambda-bundle/geomesa-lambda-processors/src/main/scala/org/geomesa/nifi/processors/lambda/LambdaDataStoreService.scala
@@ -30,8 +30,6 @@ class LambdaDataStoreService
 
   import LambdaDataStoreService.DataStoreService
 
-  import scala.collection.JavaConverters._
-
   override protected def getDataStoreParams(context: PropertyContext): Map[String, _ <: AnyRef] = {
     super.getDataStoreParams(context) ++
         Option(context.getProperty(DataStoreService))
@@ -39,7 +37,7 @@ class LambdaDataStoreService
           .toMap
   }
 
-  override protected def tryGetDataStore(params: java.util.Map[String, AnyRef]): Try[DataStore] = {
+  override protected def tryGetDataStore(): Try[DataStore] = {
     var persistence: DataStore = null
     var config: LambdaConfig = null
     try {


### PR DESCRIPTION
* This allows NiFi to recover automatically if a PostGIS database goes down and subsequently recovers
* DataStores are re-loaded when ever a "core" operation (like getting a feature writer) throws an exception