### PR TITLE
Updated NiFi to 1.24.0 and other dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version> <!-- managed from 5.3.0 -->
         <commons.net.version>3.10.0</commons.net.version> <!-- managed from 3.1 -->
-        <commons.text.version>1.10.0</commons.text.version> <!-- NOTE: versions >1.10.x break the accumulo tests -->
+        <commons.text.version>1.10.0</commons.text.version> <!-- NOTE: versions 1.11+ break the accumulo tests -->
         <wildfly.openssl.version>1.1.3.Final</wildfly.openssl.version> <!-- managed from 1.0.7.Final -->
         <gson.version>2.10.1</gson.version>
         <snappy-java.version>1.1.10.5</snappy-java.version> <!-- managed from 1.1.1.6 -->

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <properties>
         <geomesa.version>4.1.0-SNAPSHOT</geomesa.version>
-        <nifi.version>1.23.2</nifi.version>
+        <nifi.version>1.24.0</nifi.version>
 
         <scala.version>2.12.17</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
@@ -84,22 +84,22 @@
         <hbase-1.version>1.4.14</hbase-1.version>
         <kafka.version>2.8.2</kafka.version>
         <zkclient.version>0.11</zkclient.version>
-        <postgres.version>42.6.0</postgres.version>
+        <postgres.version>42.7.0</postgres.version>
 
         <curator.version>4.3.0</curator.version>
-        <netty.version>4.1.100.Final</netty.version>
+        <netty.version>4.1.101.Final</netty.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version> <!-- managed from 5.3.0 -->
         <commons.net.version>3.10.0</commons.net.version> <!-- managed from 3.1 -->
-        <commons.text.version>1.10.0</commons.text.version>
+        <commons.text.version>1.10.0</commons.text.version> <!-- NOTE: versions >1.10.x break the accumulo tests -->
         <wildfly.openssl.version>1.1.3.Final</wildfly.openssl.version> <!-- managed from 1.0.7.Final -->
         <gson.version>2.10.1</gson.version>
         <snappy-java.version>1.1.10.5</snappy-java.version> <!-- managed from 1.1.1.6 -->
-        <protobuf-java.version>3.24.4</protobuf-java.version>
+        <protobuf-java.version>3.25.1</protobuf-java.version>
         <protobuf-java.hbase.version>2.6.1</protobuf-java.hbase.version> <!-- needs to be 2.x for hbase1 -->
         <json-path.version>2.8.0</json-path.version> <!-- managed from 2.7.0 -->
-        <nimbus-jose-jwt.version>9.37</nimbus-jose-jwt.version> <!-- managed from 9.8.1 -->
+        <nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version> <!-- managed from 9.8.1 -->
         <commons-configuration.version>1.10</commons-configuration.version> <!-- managed from 1.6 -->
         <commons-configuration2.version>2.9.0</commons-configuration2.version> <!-- managed from 2.5.0 -->
         <commons-beanutils.version>1.9.4</commons-beanutils.version> <!-- managed from 1.9.3 -->
@@ -107,41 +107,43 @@
         <parquet.version>1.13.1</parquet.version>
 
         <!-- aws version -->
-        <aws.java.sdk.version>1.12.572</aws.java.sdk.version>
+        <aws.java.sdk.version>1.12.604</aws.java.sdk.version>
 
+        <!-- logging -->
         <slf4j.version>1.7.36</slf4j.version>
         <scalalogging.version>3.9.5</scalalogging.version>
         <reload4j.version>1.2.25</reload4j.version>
 
-        <specs2.version>4.20.2</specs2.version>
+        <!-- testing -->
+        <specs2.version>4.20.3</specs2.version>
         <junit.version>4.13.2</junit.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
+        <testcontainers.version>1.19.3</testcontainers.version>
 
         <test.redis.docker.tag>7-alpine</test.redis.docker.tag>
         <test.postgres.docker.tag>15.1</test.postgres.docker.tag>
-        <test.postgis.docker.tag>15-3.3</test.postgis.docker.tag>
-        <test.confluent.docker.tag>7.3.1</test.confluent.docker.tag> <!-- confluent 7.3.x corresponds to kafka 3.3.x -->
+        <test.postgis.docker.tag>15-3.4</test.postgis.docker.tag>
+        <test.confluent.docker.tag>7.3.6</test.confluent.docker.tag> <!-- confluent 7.3.x corresponds to kafka 3.3.x -->
 
         <maven.test.jvmargs>-Xms512m -Xmx4g -XX:-UseGCOverheadLimit</maven.test.jvmargs>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Maven plugin versions, latest as of 2023-09-20 -->
-        <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
+        <!-- Maven plugin versions, latest as of 2023-12-06 -->
+        <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <scala-maven-plugin.version>3.4.6</scala-maven-plugin.version>
-        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
         <nifi-nar-maven-plugin.version>1.5.1</nifi-nar-maven-plugin.version>
-        <license-maven-plugin.version>4.2</license-maven-plugin.version>
-        <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
+        <license-maven-plugin.version>4.3</license-maven-plugin.version>
+        <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     </properties>
 
     <scm>
@@ -163,6 +165,12 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-aws-service-api-nar</artifactId>
+                <version>${nifi.version}</version>
+                <type>nar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-standard-shared-nar</artifactId>
                 <version>${nifi.version}</version>
                 <type>nar</type>
             </dependency>


### PR DESCRIPTION
### CHANGES
**NiFi**
- Updated NiFi to `1.24.0`
- Added `nifi-standard-shared-nar` as a dependency (introduced in 1.24.0)

**DEPENDENCY VERSION UPDATES**
- Updated postgres to `42.7.0`
- Updated netty to `4.1.101.Final`
- Updated protobuf-java to `3.25.1`
- Updated nimbus-jose-jwt to `9.37.2`
- Updated aws.java.sdk to `1.12.604`

**TEST-RELATED VERSION UPDATES**
- Updated specs2 to `4.20.3`
- Updated testcontainers to `1.19.3`
- Updated postgis.docker to `15-3.3`
- Updated cp-kafka to `7.3.6`

**MAVEN PLUGIN VERSION UPDATES**
- Updated build-helper-maven-plugin to `3.5.0`
- Updated maven-surefire-plugin to `3.2.2`
- Updated maven-shade-plugin to `3.5.1`
- Updated license-maven-plugin to `4.3`
- Updated maven-checkstyle-plugin to `3.3.1`

### TESTING
- All of the surefire unit tests invoked by `mvn clean install` ran successfully.
- The following NiFi storage backends were all tested with sample data and worked correctly in both NiFi 1.24.0 and 1.23.2:
  - PostgreSQL/PostGIS
  - HBase 1.x and 2.x
  - Kafka
  - Redis
  - Accumulo 2.0.x and 2.1.x
  - Local file system and HDFS