### PR TITLE
Minor dependency version bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <scala.binary.version>2.12</scala.binary.version>
 
         <avro.version>1.11.3</avro.version>
-        <guava.version>32.1.3-jre</guava.version>
+        <guava.version>33.0.0-jre</guava.version>
 
         <!-- versions from geomesa -->
         <gt.version>28.2</gt.version>
@@ -80,14 +80,14 @@
         <thrift.version>0.12.0</thrift.version>
         <zookeeper.version>3.7.2</zookeeper.version>
         <hadoop.version>3.3.6</hadoop.version>
-        <hbase.version>2.5.6-hadoop3</hbase.version>
+        <hbase.version>2.5.7-hadoop3</hbase.version>
         <hbase-1.version>1.4.14</hbase-1.version>
         <kafka.version>2.8.2</kafka.version>
         <zkclient.version>0.11</zkclient.version>
         <postgres.version>42.7.0</postgres.version>
 
         <curator.version>4.3.0</curator.version>
-        <netty.version>4.1.101.Final</netty.version>
+        <netty.version>4.1.101.Final</netty.version>  <!-- NOTE: versions 4.1.102.Final+ break ConvertToGeoFileTest -->
         <jetty.version>9.4.53.v20231009</jetty.version>
         <fasterxml.jackson.version>2.15.3</fasterxml.jackson.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version> <!-- managed from 5.3.0 -->
@@ -107,7 +107,7 @@
         <parquet.version>1.13.1</parquet.version>
 
         <!-- aws version -->
-        <aws.java.sdk.version>1.12.604</aws.java.sdk.version>
+        <aws.java.sdk.version>1.12.625</aws.java.sdk.version>
 
         <!-- logging -->
         <slf4j.version>1.7.36</slf4j.version>
@@ -128,13 +128,13 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Maven plugin versions, latest as of 2023-12-06 -->
+        <!-- Maven plugin versions, latest as of 2023-12-27 -->
         <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <scala-maven-plugin.version>3.4.6</scala-maven-plugin.version>
-        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
@@ -1177,7 +1177,7 @@
                              already compiled.  The scala-maven-plugin generates .class
                              files from Java sources when its 'incremental' option is
                              turned on (as it is in the 'zinc' profile).  In this case,
-                             maven-compiler-plugin 3.0 to current (3.8.0) erroneously
+                             maven-compiler-plugin 3.0 to current (3.12.1) erroneously
                              detects changes and re-compiles the Java files unless this
                              option is turned off.  -->
                         <useIncrementalCompilation>false</useIncrementalCompilation>


### PR DESCRIPTION
**Dependency Version Bumps**
Updated guava to `33.0.0-jre`
Updated hbase to `2.5.7-hadoop3`
Updated aws-java-sdk-core to `1.12.625`

**Maven Plugin Version Bumps**
Updated maven-compiler-plugin to `3.12.1`
Updated maven-surefire-plugin to `3.2.3`

**Testing**
All maven build tests pass, and all supported NiFi back-ends work as-expected.